### PR TITLE
Security refinements

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,23 +416,6 @@
           important to protect IoT systems so that they can not be
           used to launch attacks on other computer systems.
         </p>
-        <p><!-- Security requirements for the the WoT -->
-           Security is a cross-cutting issue that needs to be
-           taken into account in all other aspects of the 
-           WoT Architecture,
-           including the Thing Description, 
-           the Scripting API, and the Protocol Bindings.
-           The Thing Description and the Scripting API should
-           support both transport and object security using
-           best practices.  
-           <!-- TODO: only mention "data" below, what about actions? -->
-           This should apply to both data produced
-           by the Things' interfaces and to the metadata stored in
-           the Thing Description and accessible via the Scripting API.
-           Binding Templates must also support the use of appropriate 
-           security mechanisms for the protocols they map to in order
-           to satisfy the "do no harm" principle.  
-        </p>
       </section>
     </section>
 
@@ -1053,7 +1036,7 @@
         Please see work in progress at 
         <a href="https://github.com/w3c/wot/tree/master/security-privacy">WoT Security and Privacy</a>.
       </p>
-      <p>
+        <p><!-- Security requirements for the the WoT -->
         Security is a cross-cutting issue that needs to be taken into account in all WoT building blocks listed in <a href="sec-building-blocks"></a>.
         W3C WoT does not define any new security mechanisms,
         but provides guidelines to apply the best practices from Web security,

--- a/index.html
+++ b/index.html
@@ -1029,16 +1029,18 @@
       <p class="ednote">
         Security and privacy considerations are still under discussion and development.
         Due to the complexity of the subject
-        we are considering producing a separate document a detailed security and privacy considerations
+        we are considering producing a separate document containing a detailed security and privacy considerations
         discussion including a threat model,
         risks, recommended mitigations, and appropriate references to best practices.  
         A summary will be included here; the content below should be considered preliminary.
-        Please see work in progress at 
+        Work in progress is located at 
         <a href="https://github.com/w3c/wot/tree/master/security-privacy">WoT Security and Privacy</a>.
+        Please file any additional security or privacy considerations and/or concerns using the <a href="https://github.com/w3c/wot-architecture/issues">GitHub Issue</a> feature.
       </p>
         <p><!-- Security requirements for the the WoT -->
-        Security is a cross-cutting issue that needs to be taken into account in all WoT building blocks listed in <a href="sec-building-blocks"></a>.
-        W3C WoT does not define any new security mechanisms,
+        Security is a cross-cutting issue that needs to be taken into account in all 
+<a href="#sec-building-blocks">WoT building blocks</a>.
+        The W3C WoT does not define any new security mechanisms,
         but provides guidelines to apply the best practices from Web security,
         IoT security,
         and information security for general software and hardware considerations.
@@ -1054,9 +1056,6 @@
       <p>
         The <a href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#scripting-api">WoT Scripting API</a> must have mechanisms to prevent malicious access to the system.
         More security mechanisms need to be applied to the <a href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#wot-runtime">WoT Runtime</a> implementation.
-      </p>
-      <p class="ednote">
-        Please file any additional security or privacy considerations and/or concerns using the <a href="https://github.com/w3c/wot-architecture/issues">GitHub Issue</a> feature.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@
           Please see the
           <a href="https://github.com/w3c/wot/tree/master/security-privacy">Security and Privacy</a>
           section of the WoT repository for work in progress.
-          In particular the following document <a href="https://github.com/w3c/wot/tree/master/security-privacy/AssetsThreatModelSecurityObjectives.md">WoT Threat Model</a> defines the main WoT security stakeholders,
+          In particular the <a href="https://github.com/w3c/wot/tree/master/security-privacy/AssetsThreatModelSecurityObjectives.md">WoT Threat Model</a> defines the main WoT security stakeholders,
            assets, attack surfaces and threats. 
         </p>
         <p><!-- Requirements -->


### PR DESCRIPTION
Merging various commits and fixes that were in flight from different people.  Revising Ed notes to point to repo (for now, in w3c/wot/security-privacy) where we intend to put some centralized content.

note: I also added anchor tags to some sections and fixed a broken hyperlink using these tags.  These changes do not affect the rendering.