### PR TITLE
non-obtrusive style for dfn links, and some link related corrections.

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,13 @@
 		}
 	};
 </script>
+<style type="text/css">
+a[href].internalDFN {
+    color: inherit;
+    border-bottom: 1px solid #99c;
+    text-decoration: none;
+}
+</style>
 </head>
 <body>
 	<section id="abstract">
@@ -965,7 +972,7 @@
 					<figcaption>Digital Twin</figcaption>
 				</figure>
 				<p></p>
-				<figure id="digital-twin">
+				<figure id="digital-twin-multiple-devices">
 					<img src="images/wot-use-cases/digital-twin-multiple-devices.png"
 						style="width: 500px;" />
 					<figcaption>Digital Twin for multiple devices</figcaption>
@@ -1588,7 +1595,7 @@
 				implementations may choose to make use of JSON-LD [[?JSON-LD11]] and graph databases to enable powerful semantic processing of the metadata.
 			</p>
 			<p>
-				A <a>Thing Description</a> (TD) describes Thing instances with general metadata such as name and id, interaction metadata based on the interaction model defined in <a href="#sec-interaction-model"></a>, and relation metadata through links to related Things or other documents on the Web.
+				A <a>Thing Description</a> (TD) describes Thing instances with general metadata such as name and id, interaction metadata based on the interaction model defined in <a href="#interaction-model"></a>, and relation metadata through links to related Things or other documents on the Web.
 				The TD can be seen as the <i>index.html for Things</i>, as it provides the entry point to learn about the provided services and related resources, both of which are described using hypermedia controls.
 			</p>
 			<p>
@@ -1617,7 +1624,7 @@
 				The IoT uses a variety of protocols for accessing devices, since no one protocol is appropriate in all contexts.
 				Thus, a central challenge for the Web of Things is to enable interactions with the plethora of different <a>IoT platforms</a>
 				(e.g., OCF, oneM2M, OMA LWM2M, OPC UA) and RESTful devices that do not following any particular standard, but provide an elidigle interface over HTTP or CoAP.
-				WoT is tackling this variety through Protocol Bindings, which must meet a number of constraints (see <a href="#sec-protocol-bindings"></a>).
+				WoT is tackling this variety through Protocol Bindings, which must meet a number of constraints (see <a href="#protocol-bindings"></a>).
 			</p>
 			<p>
 				The informal WoT Binding Templates document [[?wot-binding-templates]] provides a collection of communication metadata blueprints that explain how to interact with different <a>IoT platforms</a>.
@@ -1710,7 +1717,7 @@
 			this dual role.
 		</p>
 		<p>
-			The previous <a href="#architecture-concept"></a> shows how the WoT
+			The previous <a href="#architecture-concept">(TODO: add a reference to Architecture Concept)</a> shows how the WoT
 			building blocks conceptionally relate to each other. When
 			implementing these concepts, a more detailed view is necessary that
 			takes certain technical aspects into account. The detailed
@@ -2122,44 +2129,39 @@
 			considerations.
 		</p>
 		<p>
-			The <a href="#user-content-thing-description-td">WoT Thing
+			The <a>WoT Thing
 				Description</a> must be used together with integrity protection
 			mechanisms and access control policies. Users must ensure that no
-			sensitive information is included in the <a href="#user-content-td">TDs</a>
+			sensitive information is included in the <a>TDs</a>
 			themselves.
 		</p>
 		<p>
-			The <a href="#user-content-binding-templates">WoT Binding
+			The <a>WoT Binding
 				Templates</a> must correctly cover the security mechanisms employed by
-			the underlying <a href="#user-content-iot-platform">IoT Platform</a>
+			the underlying <a>IoT Platform</a>
 			. Due to the automation of network interactions necessary in the IoT,
-			operators need to ensure that <a href="#user-content-thing">Things</a>
+			operators need to ensure that <a>Things</a>
 			are exposed and consumed in a way that is compliant with their
 			security policies.
 		</p>
 		<section id="sec-security-consideration-runtime-risks">
 			<h2>WoT Runtime Security and Privacy Risks</h2>
 			<p>
-				The <a href="#user-content-wot-runtime">WoT Runtime</a>
-				implementation for the <a href="#user-content-scripting-api">WoT
-
-
-
-
-
-					Scripting API</a> must at least have mechanisms to prevent malicious
-				access to the system and isolate scripts in multi-tenant <a
-					href="#user-content-servient">Servients</a> . More specifically the
-				<a href="#user-content-wot-runtime">WoT Runtime</a> implementation
-				for the <a href="#user-content-scripting-api">WoT Scripting API</a>
+				The <a>WoT Runtime</a>
+				implementation for the <a>WoT
+				Scripting API</a> must at least have mechanisms to prevent malicious
+				access to the system and isolate scripts in multi-tenant 
+				<a>Servients</a> . More specifically the
+				<a>WoT Runtime</a> implementation
+				for the <a>WoT Scripting API</a>
 				should take into account the below security and privacy risks and
 				implement the recommended mitigations.
 			</p>
 			<section id="sec-security-consideration-cross-script">
 				<h5>Cross-Script Security and Privacy Risk</h5>
 				<p>
-					In basic WoT setups, all scripts running inside the <a
-						href="#user-content-wot-runtime">WoT Runtime</a> are considered
+					In basic WoT setups, all scripts running inside the
+					<a>WoT Runtime</a> are considered
 					trusted, and therefore there is no strong need to perform strict
 					isolation between each running script instance. However, depending
 					on device capabilities and deployment use case scenario risk level
@@ -2177,12 +2179,12 @@
 					<dd>
 						The WoT runtime should perform isolation of script instances and
 						their data in cases when scripts handle privacy-related or other
-						critical security data. Similarly, the <a
-							href="#user-content-wot-runtime">WoT Runtime</a> implementation
-						should perform isolation of <a href="#user-content-wot-runtime">WoT
+						critical security data. Similarly, the
+						<a>WoT Runtime</a> implementation
+						should perform isolation of <a>WoT
 							Runtime</a> instances and their data if a WoT device has more than
-						one tenant. Such isolation can be performed within the <a
-							href="#user-content-wot-runtime">WoT Runtime</a> using platform
+						one tenant. Such isolation can be performed within the
+						<a>WoT Runtime</a> using platform
 						security mechanisms available on the device. For more information
 						see Sections "WoT Servient Single-Tenant" and "WoT Servient
 						Multi-Tenant" of [[!WOT-SECURITY-CONSIDERATIONS#]].
@@ -2200,9 +2202,9 @@
 				<dl>
 					<dt>Mitigation:</dt>
 					<dd>
-						The <a href="#user-content-wot-runtime">WoT Runtime</a> should
+						The <a>WoT Runtime</a> should
 						avoid directly exposing the native device interfaces to the script
-						developers. Instead a <a href="#user-content-wot-runtime">WoT
+						developers. Instead a <a>WoT
 							Runtime</a> implementation should provide a hardware abstraction
 						layer for accessing the native device interfaces. Such hardware
 						abstraction layer should refuse to execute commands that might put
@@ -2217,7 +2219,7 @@
 			<section id="sec-security-consideration-update-provisioning">
 				<h5>Provisioning and Update Security Risk</h5>
 				<p>
-					If the <a href="#user-content-wot-runtime">WoT Runtime</a>
+					If the <a>WoT Runtime</a>
 					implementation supports post-manufacturing provisioning or updates
 					of itself, WoT scripts, or any related data (including security
 					credentials), it can be a major attack vector. An attacker can try
@@ -2228,8 +2230,8 @@
 				<dl>
 					<dt>Mitigation:</dt>
 					<dd>
-						Post-manufacturing provisioning or update of scripts, the <a
-							href="#user-content-wot-runtime">WoT Runtime</a> itself or any
+						Post-manufacturing provisioning or update of scripts, the
+						<a>WoT Runtime</a> itself or any
 						related data should be done in a secure fashion. A set of
 						recommendations for secure update and post-manufacturing
 						provisioning can be found in [[!WOT-SECURITY-CONSIDERATIONS]].
@@ -2239,7 +2241,7 @@
 			<section id="sec-security-consideration-credentials-storage">
 				<h5>Security Credentials Storage Security and Privacy Risk</h5>
 				<p>
-					Typically the <a href="#user-content-wot-runtime">WoT Runtime</a>
+					Typically the <a>WoT Runtime</a>
 					needs to store the security credentials that are provisioned to a
 					WoT device to operate in WoT network. If an attacker can compromise
 					the confidentiality or integrity of these credentials, then it can
@@ -2249,15 +2251,14 @@
 				<dl>
 					<dt>Mitigation:</dt>
 					<dd>
-						The <a href="#user-content-wot-runtime">WoT Runtime</a> should
+						The <a>WoT Runtime</a> should
 						securely store the provisioned security credentials, guaranteeing
 						their integrity and confidentiality. In case there are more than
-						one tenant on a single WoT-enabled device, a <a
-							href="#user-content-wot-runtime">WoT Runtime</a> implementation
+						one tenant on a single WoT-enabled device, a <a>WoT Runtime</a> implementation
 						should guarantee isolation of each tenant provisioned security
 						credentials. Additionally, in order to minimize a risk that
-						provisioned security credentials get compromised, the <a
-							href="#user-content-wot-runtime">WoT Runtime</a> implementation
+						provisioned security credentials get compromised, the
+						<a>WoT Runtime</a> implementation
 						should not expose any API for scripts to query the provisioned
 						security credentials.
 					</dd>
@@ -2526,7 +2527,7 @@
 				<figcaption>Servient on Smartphone</figcaption>
 			</figure>
 			<p>
-				shows an example of a <a href="#user-content-servient">Servient</a>
+				shows an example of a <a>Servient</a>
 				on a smartphone, which can act as a gateway to existing devices
 				(e.g., via Bluetooth or local Wi-Fi). The Web browser with the user
 				interface can either run on the smartphone directly or remotely on a
@@ -2539,7 +2540,7 @@
 					<ul>
 						<li>WoT Client discovers an electronic appliance when the
 							remote controller is nearby [nearby discovery].</li>
-						<li>WoT Client discovers <a href="#user-content-servient">Servient</a>
+						<li>WoT Client discovers <a>Servient</a>
 							remotely when the remote controller is outside [remote
 							discovery].
 						</li>
@@ -2566,27 +2567,27 @@
 				<figcaption>Servient on Gateway</figcaption>
 			</figure>
 			<p>
-				shows an example of a <a href="#user-content-servient">Servient</a>
+				shows an example of a <a>Servient</a>
 				on a gateway. Gateway are often introduced as a home automation
 				and/or home energy management solution. In the case of consumer
 				electronics, there are very wide variety of physical communication
 				formats such as WiFi, 802.15.4g, Bluetooth Low Energy, HDPLC and so
 				on. In order to normalize those variations, almost all home
-				automation systems introduce a gateway. In , a <a
-					href="#user-content-servient">Servient</a> wraps various mechanisms
+				automation systems introduce a gateway. In , a
+				<a>Servient</a> wraps various mechanisms
 				for communicating with legacy devices and provides to other clients
 				a universal device accessing method. Inside the home,
 				HTTP/TCP/IP/WiFi can then be used as the sole unfied communication
-				method between the <a href="#user-content-servient">Servient</a> on
+				method between the <a>Servient</a> on
 				the gateway and a user interface device such as a Web broswer.
 			</p>
 			<dl>
 				<dt>Discovery</dt>
 				<dd>
 					<ul>
-						<li><a href="#user-content-servient">Servient</a> discovers
+						<li><a>Servient</a> discovers
 							electronic appliances nearby [nearby discovery].</li>
-						<li>WoT Client discovers <a href="#user-content-servient">Servient</a>
+						<li>WoT Client discovers <a>Servient</a>
 							remotely [remote discovery].
 						</li>
 					</ul>
@@ -2608,16 +2609,16 @@
 		<section>
 			<h2>Servient on Cloud and Gateway</h2>
 			<p>
-				Client Apps can control devices at home through a <a
-					href="#user-content-servient">Servient</a> on a gateway. But in
+				Client Apps can control devices at home through a
+				<a>Servient</a> on a gateway. But in
 				this case the location of client apps is restricted to the home,
 				because physical communication path "WiFi" and/or wired Ethernet
 				between gateway and client apps such as a Web browser is limited to
 				the physical domain provided by the WiFi signal. To provide for
 				controlling devices at home from outside the house, a HTTP/TCP/IP
-				interface to a <a href="#user-content-servient">Servient</a> running
+				interface to a <a>Servient</a> running
 				in the cloud with a globally reachable address could be used.
-				However, in this case the <a href="#user-content-servient">Servient</a>
+				However, in this case the <a>Servient</a>
 				in the cloud cannot generally access devices running in the home
 				through only local interfaces such as Bluetooth.
 			</p>
@@ -2626,40 +2627,39 @@
 				<figcaption>Servient on Cloud Server and Gateway</figcaption>
 			</figure>
 			<p>
-				shows an example of <a href="#user-content-servient">Servient</a>
-				running on a cloud server paired with another <a
-					href="#user-content-servient">Servient</a> running on a gateway. In
-				the case of , a browser accesses the <a
-					href="#user-content-servient">Servient</a> on the cloud Server
-				named "Cloud". This <a href="#user-content-servient">Servient</a>
+				shows an example of <a>Servient</a>
+				running on a cloud server paired with another
+				<a>Servient</a> running on a gateway. In
+				the case of , a browser accesses the
+				<a>Servient</a> on the cloud Server
+				named "Cloud". This <a>Servient</a>
 				provides its interface through the Internet globally. So, wherever a
-				browser user is, they can access this <a
-					href="#user-content-servient">Servient</a> . The <a
-					href="#user-content-servient">Servient</a> on "Cloud" can accept
+				browser user is, they can access this <a>Servient</a> . The
+				<a>Servient</a> on "Cloud" can accept
 				the request of the browser and/or other application through HTTP,
-				CoAP, and so on. Then the <a href="#user-content-servient">Servient</a>
-				on the cloud server finds out the route to access another <a
-					href="#user-content-servient">Servient</a> on the gateway. After
-				finding out the route, the <a href="#user-content-servient">Servient</a>
-				on the cloud server transfers the request from the browser to the <a
-					href="#user-content-servient">Servient</a> on the gateway. After
+				CoAP, and so on. Then the <a>Servient</a>
+				on the cloud server finds out the route to access another
+				<a>Servient</a> on the gateway. After
+				finding out the route, the <a>Servient</a>
+				on the cloud server transfers the request from the browser to the
+				<a>Servient</a> on the gateway. After
 				that, the gateway processes the request according the use case. The
-				<a href="#user-content-thing-description-td">Thing Description</a>
-				of the <a href="#user-content-servient">Servient</a> on the cloud
+				<a>Thing Description</a>
+				of the <a>Servient</a> on the cloud
 				server can be just a mirror of that on the gateway, since it will
 				generally just pass interactions directly through. More generally,
-				though, one or both <a href="#user-content-servient">Servients</a>
+				though, one or both <a>Servients</a>
 				can provide services such as privacy filtering or sub-setting. When
-				the user is home, they can also access the <a
-					href="#user-content-servient">Servient</a> in the gateway directly.
+				the user is home, they can also access the
+				<a>Servient</a> in the gateway directly.
 			</p>
 			<dl>
 				<dt>Discovery</dt>
 				<dd>
 					<ul>
-						<li><a href="#user-content-servient">Servient</a> discovers
+						<li><a>Servient</a> discovers
 							WoT Server remotely [remote discovery].</li>
-						<li>WoT Client discovers <a href="#user-content-servient">Servient</a>
+						<li>WoT Client discovers <a>Servient</a>
 							remotely [remote discovery].
 						</li>
 					</ul>
@@ -2685,19 +2685,17 @@
 				<figcaption>Servient on Cloud Server Only</figcaption>
 			</figure>
 			<p>
-				shows a second example of <a href="#user-content-servient">Servients</a>
-				in the cloud. In this case, a browser accesses a <a
-					href="#user-content-servient">Servient</a> on a cloud server,
-				similar to . This <a href="#user-content-servient">Servient</a>
+				shows a second example of <a>Servients</a>
+				in the cloud. In this case, a browser accesses a
+				<a>Servient</a> on a cloud server,
+				similar to . This <a>Servient</a>
 				provides access through the global Internet. So, wherever the
-				browser user is, they can access this <a
-					href="#user-content-servient">Servient</a> . The cloud <a
-					href="#user-content-servient">Servient</a> accepts the requests of
+				browser user is, they can access this
+				<a>Servient</a> . The cloud <a>Servient</a> accepts the requests of
 				the browser and/or other applications through HTTP, CoAP, etc. Then
 				it finds out the route to access a proprietry discovery service
-				running on a gateway. In , the <a href="#user-content-servient">Servient</a>
-				running in the cloud could talk to another <a
-					href="#user-content-servient">Servient</a> running on the gateway.
+				running on a gateway. In , the <a>Servient</a>
+				running in the cloud could talk to another <a>Servient</a> running on the gateway.
 				However, many service providers have already provided IoT services
 				using proprietary IoT interfaces or some other IoT standard. In this
 				case, the gateway can still support the same functionalities, as in
@@ -2737,8 +2735,7 @@
 				integration into the Web browser will be added as the WG drafts
 				progress.</p>
 			<p>
-				<a href="#architecture-browser"></a> shows how a <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-servient">Servient</a>
+				<a href="#architecture-browser"></a> shows how a <a>Servient</a>
 				implementation for Web browsers would look like.
 			</p>
 			<figure id="architecture-browser">
@@ -2753,24 +2750,18 @@
 				visualization and user interaction.
 			</p>
 			<p>
-				The <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-scripting-api">WoT
+				The <a>WoT
 					Scripting API</a> needs to be added by a WoT library loaded together
 				with the application scripts by the Web page. This library would
-				also implement <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-td">TD</a>
-				handling (i.e., parsing for consuming <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-thing">Things</a>
-				and generating for exposing <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-thing">Things</a>)
+				also implement <a>TD</a>
+				handling (i.e., parsing for consuming <a>Things</a>
+				and generating for exposing <a>Things</a>)
 				and provide glue code to use the browser APIs. The other aspects of
-				the <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-wot-runtime">WoT
+				the <a>WoT
 					Runtime</a> are provided by the browser JavaScript runtime system.
 			</p>
 			<p>
-				The <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-protocol-binding">Protocol
+				The <a>Protocol
 					Bindings</a> are limited to the protocols implemented by Web browsers.
 				These are:
 			</p>
@@ -2785,8 +2776,7 @@
 			</ul>
 			<p>
 				The other browser APIs (e.g., Geolocation, Vibration, and Web
-				Storage) are comparable to the System API of normal <a
-					href="https://github.com/w3c/wot-architecture/blob/master/terminology.md#user-content-servient">Servients</a>
+				Storage) are comparable to the System API of normal <a>Servients</a>
 				and can enable access to local hardware.
 			</p>
 		</section>


### PR DESCRIPTION
Based on Issue #85, I update CSS and other link problems.

Currently, following problems are exist:
- a dangling link in [Servient Implementation](https://w3c.github.io/wot-architecture/#servient-implementation).  I think it will be resolved when Issue #88 and #83 is closed.
- a lot of 'Normative references in informative sections are not allowed.'   The warnings are only displayed when using Firefox.  I think this is a problem of ReSpec.