### PR TITLE
Add 6.5 Inter connection of servients

### DIFF
--- a/index.html
+++ b/index.html
@@ -1712,15 +1712,15 @@
 				HTTP methods such as PUT and GET are assigned to implement the
 				abstract methods. WoT clients can retrieve and change device
 				settings or device attributes defined in TDs through those abstract
-				methods. In a device servient, TD manager creates an ExposedThing
-				based on TD. TD manager also advertises a TD to other servients, or
-				provides other servients with a TD upon request. A device servient’s
+				methods. In a device servient, WoT Servient Life Cycle Management (S-LCM)
+				creates an ExposedThing based on TD. S-LCM also advertises a TD to other servients, or
+				provides other servients with a TD upon request. A device servient's
 				functions are usually implemented as hardware, and those functions
-				are accessible through its firmware. An ExposedThing’s abstract
+				are accessible through its firmware. An ExposedThing's abstract
 				interface is translated into hardware commands by a device interface
 				adapter. A device interface adapter is a custom software developed
 				for each specific type of hardware. In an application servient, on
-				the other hand, a TD manager obtains TDs by getting one from
+				the other hand, a S-LCM obtains TDs by getting one from
 				location advertised by other servients or requesting other servients
 				of TDs, and creates a ConsumedThing based on the obtained TD.
 				Functions of an application servient are usually implemented as an
@@ -1739,13 +1739,13 @@
 				structure of a proxy servient that connects a device servient and
 				application servient together.</p>
 				<p>A runtime in a proxy servient has both ExposedThing and
-				ConsumedThing functionality. A TD manager, similar to that of an
+				ConsumedThing functionality. A S-LCM, similar to that of an
 				application servient, obtains a TD of a device servient, and creates
-				a ConsumedThing. At the same time, a TD manager creates a shadow of
+				a ConsumedThing. At the same time, a S-LCM creates a shadow of
 				the device as well as a TD for the shadow device where the
 				identifier is a new one and protocol bindings are appropriately
 				described to serve for the application. An ExposedThing is created
-				based on this TD, and a TD manager notifies other servients of the
+				based on this TD, and a S-LCM notifies other servients of the
 				TD.</p>
 				<figure id="simple-conf-application-proxy-device">
 					<img src="images/arch-simple-conf-application-proxy-device.png" />

--- a/index.html
+++ b/index.html
@@ -1694,6 +1694,66 @@
 			<p class="ednote" title="TODO">Explain how to use and apply
 				guidelines.</p>
 		</section>
+		
+		<section>
+			<h3>Inter Connection of Servients</h3>
+			<p>
+				This section describes below how to inter connect among the servients.
+			</p>
+			
+			<section>
+				<h3>Inter connection between appcation and device servients</h3>
+				<p>First, inner structure of a servient is explained based on the
+				structure of an application servient and a device servient. WoT
+				runtime defines an abstract interface that contains methods such as
+				READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
+				devices. When a servient communicates over a network, those methods
+				are bound to concrete protocols. For example, in the case of HTTP,
+				HTTP methods such as PUT and GET are assigned to implement the
+				abstract methods. WoT clients can retrieve and change device
+				settings or device attributes defined in TDs through those abstract
+				methods. In a device servient, TD manager creates an ExposedThing
+				based on TD. TD manager also advertises a TD to other servients, or
+				provides other servients with a TD upon request. A device servient’s
+				functions are usually implemented as hardware, and those functions
+				are accessible through its firmware. An ExposedThing’s abstract
+				interface is translated into hardware commands by a device interface
+				adapter. A device interface adapter is a custom software developed
+				for each specific type of hardware. In an application servient, on
+				the other hand, a TD manager obtains TDs by getting one from
+				location advertised by other servients or requesting other servients
+				of TDs, and creates a ConsumedThing based on the obtained TD.
+				Functions of an application servient are usually implemented as an
+				application. The abstract interface of a ConsumedThing is provided
+				as a programming language (such as JavaScript) interface, and the
+				application achieves its functions by using this interface.</p>
+				<figure id="simple-conf-application-device">
+					<img src="images/arch-simple-conf-application-device.png" />
+					<figcaption>Simple configuration of application and
+						device</figcaption>
+				</figure>			
+			</section>
+			<section>
+				<h3>Inter connection with Proxy Servient</h3>
+				<p>Next, inner structure of a servient is explained based on the
+				structure of a proxy servient that connects a device servient and
+				application servient together.</p>
+				<p>A runtime in a proxy servient has both ExposedThing and
+				ConsumedThing functionality. A TD manager, similar to that of an
+				application servient, obtains a TD of a device servient, and creates
+				a ConsumedThing. At the same time, a TD manager creates a shadow of
+				the device as well as a TD for the shadow device where the
+				identifier is a new one and protocol bindings are appropriately
+				described to serve for the application. An ExposedThing is created
+				based on this TD, and a TD manager notifies other servients of the
+				TD.</p>
+				<figure id="simple-conf-application-proxy-device">
+					<img src="images/arch-simple-conf-application-proxy-device.png" />
+					<figcaption>Simple configuration with proxy</figcaption>
+				</figure>
+			</section>
+		</section>		
+		
 	</section>
 	
 	<section>
@@ -1893,90 +1953,6 @@
 			web of Things as a whole works. The architecture described here is
 			derived from the Web of Things use cases as well as technical
 			requirements extracted from them.</p>
-
-
-		<section>
-			<h2>Device Servients</h2>
-			<p class="ednote" title="TODO">Potentially move content from other places here.</p>			
-			<section id="sec-WoT-servient-architecture-simple-config">
-			<h2>Simple configuration of WoT servient</h2>
-			<p>The remainder of this section discusses and clarifies the
-				inner structure of a servient.</p>
-
-			<p>Below is a WoT architecture diagram that summarizes the inner
-				structure of a WoT servient. A runtime creates ExposedThing or
-				ConsumedThing based on TDs, provides an abstract interface that
-				through protocol binding can interact with other servients. Note
-				that the diagram also contains a legacy device that does not by
-				itself support WoT abstract interface. A device interface adapter
-				converts legacy interface into an abstract interface to allow them
-				to interact with the runtime.</p>
-			<figure id="simple-conf-wot-servient">
-				<img src="images/arch-simple-conf-wot-servient.png" />
-				<figcaption>Simple configuration of WoT servient</figcaption>
-			</figure>
-		</section>
-				
-		</section>
-		<section>
-			<h2>Application Servients</h2>
-			<p class="ednote" title="TODO">Potentially move content from other places here.</p>			
-			<p>First, inner structure of a servient is explained based on the
-				structure of an application servient and a device servient. WoT
-				runtime defines an abstract interface that contains methods such as
-				READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
-				devices. When a servient communicates over a network, those methods
-				are bound to concrete protocols. For example, in the case of HTTP,
-				HTTP methods such as PUT and GET are assigned to implement the
-				abstract methods. WoT clients can retrieve and change device
-				settings or device attributes defined in TDs through those abstract
-				methods. In a device servient, TD manager creates an ExposedThing
-				based on TD. TD manager also advertises a TD to other servients, or
-				provides other servients with a TD upon request. A device servient’s
-				functions are usually implemented as hardware, and those functions
-				are accessible through its firmware. An ExposedThing’s abstract
-				interface is translated into hardware commands by a device interface
-				adapter. A device interface adapter is a custom software developed
-				for each specific type of hardware. In an application servient, on
-				the other hand, a TD manager obtains TDs by getting one from
-				location advertised by other servients or requesting other servients
-				of TDs, and creates a ConsumedThing based on the obtained TD.
-				Functions of an application servient are usually implemented as an
-				application. The abstract interface of a ConsumedThing is provided
-				as a programming language (such as JavaScript) interface, and the
-				application achieves its functions by using this interface.</p>
-			<figure id="simple-conf-application-device">
-				<img src="images/arch-simple-conf-application-device.png" />
-				<figcaption>Simple configuration of application and
-					device</figcaption>
-			</figure>			
-		</section>
-		<section>
-			<h2>Proxy Servients</h2>
-			<p class="ednote" title="TODO">Potentially move content from other places here.</p>			
-			<p>Next, inner structure of a servient is explained based on the
-				structure of a proxy servient that connects a device servient and
-				application servient together.</p>
-			<p>A runtime in a proxy servient has both ExposedThing and
-				ConsumedThing functionality. A TD manager, similar to that of an
-				application servient, obtains a TD of a device servient, and creates
-				a ConsumedThing. At the same time, a TD manager creates a shadow of
-				the device as well as a TD for the shadow device where the
-				identifier is a new one and protocol bindings are appropriately
-				described to serve for the application. An ExposedThing is created
-				based on this TD, and a TD manager notifies other servients of the
-				TD.</p>
-			<figure id="simple-conf-application-proxy-device">
-				<img src="images/arch-simple-conf-application-proxy-device.png" />
-				<figcaption>Simple configuration with proxy</figcaption>
-			</figure>
-		</section>
-		
-		<section>
-			<h2>Thing Directories</h2>
-			<p class="ednote" title="TODO">Try to explain this component in
-				open way, as specification is not available yet.</p>
-		</section>
 
 		<section id="sec-deployment-cloud-rm">
 			<h2>Devices in a Local Network Controlled from a Cloud</h2>


### PR DESCRIPTION
The new building blocks was defined as common functions and structure as a result of the consideration of Use cases and 5.2 high-level architecture. Therefore how to inter-connect among servients should be decribed in the same section of "6. WoT Building Blocks".
On the other hands, the section 8 can be focused to the deployments in the actual situation. For example, "8.5 Devices in a Local Network Controlled from a Cloud" and "8.6 Service-to-Service across multiple Domains" are typical cases in the commercial IoT systems.