### PR TITLE
fixing terminology section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2191,6 +2191,63 @@ a[href].internalDFN {
 				the <a>WoT Thing Description</a>.
 			</p>
 		</section>
+		<section>
+			<h3>Inter Connection of Servients</h3>
+			<p>This section describes below how to inter connect among the
+				servients.</p>
+
+			<section>
+				<h3>Inter connection between application and device servients</h3>
+				<p>First, inner structure of a servient is explained based on
+					the structure of an application servient and a device servient. WoT
+					runtime defines an abstract interface that contains methods such as
+					READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
+					devices. When a servient communicates over a network, those methods
+					are bound to concrete protocols. For example, in the case of HTTP,
+					HTTP methods such as PUT and GET are assigned to implement the
+					abstract methods. WoT clients can retrieve and change device
+					settings or device attributes defined in TDs through those abstract
+					methods. In a device servient, WoT Servient Life Cycle Management
+					(S-LCM) creates an ExposedThing based on TD. S-LCM also advertises
+					a TD to other servients, or provides other servients with a TD upon
+					request. A device servient's functions are usually implemented as
+					hardware, and those functions are accessible through its firmware.
+					An ExposedThing's abstract interface is translated into hardware
+					commands by a device interface adapter. A device interface adapter
+					is a custom software developed for each specific type of hardware.
+					In an application servient, on the other hand, a S-LCM obtains TDs
+					by getting one from location advertised by other servients or
+					requesting other servients of TDs, and creates a ConsumedThing
+					based on the obtained TD. Functions of an application servient are
+					usually implemented as an application. The abstract interface of a
+					ConsumedThing is provided as a programming language (such as
+					JavaScript) interface, and the application achieves its functions
+					by using this interface.</p>
+				<figure id="simple-conf-application-device">
+					<img src="images/arch-simple-conf-application-device.png" />
+					<figcaption>Simple configuration of application and
+						device</figcaption>
+				</figure>
+			</section>
+			<section>
+				<h3>Inter connection with Proxy Servient</h3>
+				<p>Next, inner structure of a servient is explained based on the
+					structure of a proxy servient that connects a device servient and
+					application servient together.</p>
+				<p>A runtime in a proxy servient has both ExposedThing and
+					ConsumedThing functionality. A S-LCM, similar to that of an
+					application servient, obtains a TD of a device servient, and
+					creates a ConsumedThing. At the same time, a S-LCM creates a shadow
+					of the device as well as a TD for the shadow device where the
+					identifier is a new one and protocol bindings are appropriately
+					described to serve for the application. An ExposedThing is created
+					based on this TD, and a S-LCM notifies other servients of the TD.</p>
+				<figure id="simple-conf-application-proxy-device">
+					<img src="images/arch-simple-conf-application-proxy-device.png" />
+					<figcaption>Simple configuration with proxy</figcaption>
+				</figure>
+			</section>
+		</section>
 	</section>
 
 	<!-- DEPLOYMENT SCENARIOS  -->
@@ -2300,63 +2357,6 @@ a[href].internalDFN {
 				<figcaption>Multiple cloud connect through proxy
 					synchronization</figcaption>
 			</figure>
-		</section>
-		<section>
-			<h3>Inter Connection of Servients</h3>
-			<p>This section describes below how to inter connect among the
-				servients.</p>
-
-			<section>
-				<h3>Inter connection between application and device servients</h3>
-				<p>First, inner structure of a servient is explained based on
-					the structure of an application servient and a device servient. WoT
-					runtime defines an abstract interface that contains methods such as
-					READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
-					devices. When a servient communicates over a network, those methods
-					are bound to concrete protocols. For example, in the case of HTTP,
-					HTTP methods such as PUT and GET are assigned to implement the
-					abstract methods. WoT clients can retrieve and change device
-					settings or device attributes defined in TDs through those abstract
-					methods. In a device servient, WoT Servient Life Cycle Management
-					(S-LCM) creates an ExposedThing based on TD. S-LCM also advertises
-					a TD to other servients, or provides other servients with a TD upon
-					request. A device servient's functions are usually implemented as
-					hardware, and those functions are accessible through its firmware.
-					An ExposedThing's abstract interface is translated into hardware
-					commands by a device interface adapter. A device interface adapter
-					is a custom software developed for each specific type of hardware.
-					In an application servient, on the other hand, a S-LCM obtains TDs
-					by getting one from location advertised by other servients or
-					requesting other servients of TDs, and creates a ConsumedThing
-					based on the obtained TD. Functions of an application servient are
-					usually implemented as an application. The abstract interface of a
-					ConsumedThing is provided as a programming language (such as
-					JavaScript) interface, and the application achieves its functions
-					by using this interface.</p>
-				<figure id="simple-conf-application-device">
-					<img src="images/arch-simple-conf-application-device.png" />
-					<figcaption>Simple configuration of application and
-						device</figcaption>
-				</figure>
-			</section>
-			<section>
-				<h3>Inter connection with Proxy Servient</h3>
-				<p>Next, inner structure of a servient is explained based on the
-					structure of a proxy servient that connects a device servient and
-					application servient together.</p>
-				<p>A runtime in a proxy servient has both ExposedThing and
-					ConsumedThing functionality. A S-LCM, similar to that of an
-					application servient, obtains a TD of a device servient, and
-					creates a ConsumedThing. At the same time, a S-LCM creates a shadow
-					of the device as well as a TD for the shadow device where the
-					identifier is a new one and protocol bindings are appropriately
-					described to serve for the application. An ExposedThing is created
-					based on this TD, and a S-LCM notifies other servients of the TD.</p>
-				<figure id="simple-conf-application-proxy-device">
-					<img src="images/arch-simple-conf-application-proxy-device.png" />
-					<figcaption>Simple configuration with proxy</figcaption>
-				</figure>
-			</section>
 		</section>
 
 	</section>

--- a/index.html
+++ b/index.html
@@ -291,7 +291,15 @@ a[href].internalDFN {
 				software object for the application in the local runtime
 				environment.</dd>
 			<dt>
-				<dfn>Consumed Thing</dfn>
+				<dt>
+					<dfn>CoAP</dfn>
+				</dt>
+				<dd>Acronym for Constrained Application Protocol [[RFC7252]]</dd>
+				<dt>
+					<dfn>CWT</dfn>
+				</dt>
+				<dd>CBOR Web Token</dd>
+					<dfn>Consumed Thing</dfn>
 			</dt>
 			<dd>A software object instance created through the WoT object of
 				the Scripting API that represents a remote Thing used by the local
@@ -356,7 +364,20 @@ a[href].internalDFN {
 			<dd>A specific IoT ecosystem such as OCF, oneM2M, or Mozilla
 				Project Things with its own specifications for application-facing
 				APIs, data model, and protocols or protocol configurations.</dd>
-			<dt>
+				<dt>
+					<dfn>JSON-LD</dfn>
+				</dt>
+				<dd>
+					A JSON document that is augmented with support for Linked Data by
+					providing an
+					<code>@context</code>
+					property with a defining URI [[json-ld]].
+				</dd>
+				<dt>
+					<dfn>JWT</dfn>
+				</dt>
+				<dd>JSON Web Token [[RFC7519]]</dd>
+				<dt>
 				<dfn>Local Discovery</dfn>
 			</dt>
 			<dd>A discovery method that can discover Things directly
@@ -369,6 +390,11 @@ a[href].internalDFN {
 				Descriptions is provided manually (e.g., through user configuration
 				or hard-coding in a script).</dd>
 			<dt>
+				<dfn>MQTT</dfn>
+					<dd> <i>Message Queuing Telemetry Transport</i> is a publish-subscribe-based 
+						messaging protocol.[[!MQTT]] </dd>
+
+
 				<dfn>Nearby Discovery</dfn>
 			</dt>
 			<dd>A discovery method where the physical location is considered
@@ -391,7 +417,12 @@ a[href].internalDFN {
 			<dd>The set of mapping rules from an Interaction Affordance to
 				concrete messages of a specific protocol.</dd>
 			<dt>
-				<dfn>Remote Discovery</dfn>
+				<dt>
+					<dfn>RDF</dfn>
+				</dt>
+				<dd>The Resource Description Framework (RDF) of the Semantic Web
+					[[rdf-concepts]]</dd>
+					<dfn>Remote Discovery</dfn>
 			</dt>
 			<dd>A discovery method which supports lookup of remote Things
 				also beyond network boundaries, for instance by using a directory
@@ -453,7 +484,11 @@ a[href].internalDFN {
 			</dt>
 			<dd>The underlying, standardized application layer protocol
 				without application-specific options or subprotocol mechanisms.</dd>
-			<dt>
+				<dt>
+					<dfn>WoT</dfn>
+				</dt>
+				<dd>The Web of Things initiatiove in the W3C.</dd>
+				<dt>
 				<dfn>WoT Client</dfn>
 			</dt>
 			<dd>An entity that can connect with a network interface
@@ -475,43 +510,20 @@ a[href].internalDFN {
 				<dfn>WoT Runtime</dfn>
 			</dt>
 			<dd>A runtime system for application scripts with the WoT
-				Scripting API. Implementing a WoT Runtime is optional for Servients.</dd>
+				Scripting API. Implementing a WoT Runtime is optional for Servients.
+			
+				The WoT Runtime should be the component that instantiates 
+				Consumed Things and Exposed Things as software objects, 
+				manages their state, and generates the TDs. 
+				It communicates with other components such as the Binding implementations 
+				and application scripts (the WoT Scripting API being one way).</dd>
 			<dt>
 				<dfn>WoT Server</dfn>
 			</dt>
 			<dd>An entity that exposes a network interface consistent with a
 				WoT Thing Description. WoT Server is also used to refer to a
 				Servient in server role only.</dd>
-			<dt>
-				<dfn>CoAP</dfn>
-			</dt>
-			<dd>Acronym for Constrained Application Protocol [[RFC7252]]</dd>
-			<dt>
-				<dfn>CWT</dfn>
-			</dt>
-			<dd>CBOR Web Token</dd>
-			<dt>
-				<dfn>JSON-LD</dfn>
-			</dt>
-			<dd>
-				A JSON document that is augmented with support for Linked Data by
-				providing an
-				<code>@context</code>
-				property with a defining URI [[json-ld]].
-			</dd>
-			<dt>
-				<dfn>JWT</dfn>
-			</dt>
-			<dd>JSON Web Token [[RFC7519]]</dd>
-			<dt>
-				<dfn>RDF</dfn>
-			</dt>
-			<dd>The Resource Description Framework (RDF) of the Semantic Web
-				[[rdf-concepts]]</dd>
 		</dl>
-		<p class="ednote" title="Additional Terms">TODO: add missing
-			terms, such as WoT, WoT Containers, MQTT, TD manager</p>
-		<p>The definitions CWT, JWT, RDF are not used in this document.</p>
 	</section>
 
 	<!--  USE CASES -->
@@ -1986,65 +1998,6 @@ a[href].internalDFN {
 			<p class="ednote" title="TODO">Explain how to use and apply
 				guidelines.</p>
 		</section>
-
-		<section>
-			<h3>Inter Connection of Servients</h3>
-			<p>This section describes below how to inter connect among the
-				servients.</p>
-
-			<section>
-				<h3>Inter connection between application and device servients</h3>
-				<p>First, inner structure of a servient is explained based on
-					the structure of an application servient and a device servient. WoT
-					runtime defines an abstract interface that contains methods such as
-					READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
-					devices. When a servient communicates over a network, those methods
-					are bound to concrete protocols. For example, in the case of HTTP,
-					HTTP methods such as PUT and GET are assigned to implement the
-					abstract methods. WoT clients can retrieve and change device
-					settings or device attributes defined in TDs through those abstract
-					methods. In a device servient, WoT Servient Life Cycle Management
-					(S-LCM) creates an ExposedThing based on TD. S-LCM also advertises
-					a TD to other servients, or provides other servients with a TD upon
-					request. A device servient's functions are usually implemented as
-					hardware, and those functions are accessible through its firmware.
-					An ExposedThing's abstract interface is translated into hardware
-					commands by a device interface adapter. A device interface adapter
-					is a custom software developed for each specific type of hardware.
-					In an application servient, on the other hand, a S-LCM obtains TDs
-					by getting one from location advertised by other servients or
-					requesting other servients of TDs, and creates a ConsumedThing
-					based on the obtained TD. Functions of an application servient are
-					usually implemented as an application. The abstract interface of a
-					ConsumedThing is provided as a programming language (such as
-					JavaScript) interface, and the application achieves its functions
-					by using this interface.</p>
-				<figure id="simple-conf-application-device">
-					<img src="images/arch-simple-conf-application-device.png" />
-					<figcaption>Simple configuration of application and
-						device</figcaption>
-				</figure>
-			</section>
-			<section>
-				<h3>Inter connection with Proxy Servient</h3>
-				<p>Next, inner structure of a servient is explained based on the
-					structure of a proxy servient that connects a device servient and
-					application servient together.</p>
-				<p>A runtime in a proxy servient has both ExposedThing and
-					ConsumedThing functionality. A S-LCM, similar to that of an
-					application servient, obtains a TD of a device servient, and
-					creates a ConsumedThing. At the same time, a S-LCM creates a shadow
-					of the device as well as a TD for the shadow device where the
-					identifier is a new one and protocol bindings are appropriately
-					described to serve for the application. An ExposedThing is created
-					based on this TD, and a S-LCM notifies other servients of the TD.</p>
-				<figure id="simple-conf-application-proxy-device">
-					<img src="images/arch-simple-conf-application-proxy-device.png" />
-					<figcaption>Simple configuration with proxy</figcaption>
-				</figure>
-			</section>
-		</section>
-
 	</section>
 
 	<section>
@@ -2332,6 +2285,64 @@ a[href].internalDFN {
 					synchronization</figcaption>
 			</figure>
 		</section>
+		<section>
+				<h3>Inter Connection of Servients</h3>
+				<p>This section describes below how to inter connect among the
+					servients.</p>
+	
+				<section>
+					<h3>Inter connection between application and device servients</h3>
+					<p>First, inner structure of a servient is explained based on
+						the structure of an application servient and a device servient. WoT
+						runtime defines an abstract interface that contains methods such as
+						READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
+						devices. When a servient communicates over a network, those methods
+						are bound to concrete protocols. For example, in the case of HTTP,
+						HTTP methods such as PUT and GET are assigned to implement the
+						abstract methods. WoT clients can retrieve and change device
+						settings or device attributes defined in TDs through those abstract
+						methods. In a device servient, WoT Servient Life Cycle Management
+						(S-LCM) creates an ExposedThing based on TD. S-LCM also advertises
+						a TD to other servients, or provides other servients with a TD upon
+						request. A device servient's functions are usually implemented as
+						hardware, and those functions are accessible through its firmware.
+						An ExposedThing's abstract interface is translated into hardware
+						commands by a device interface adapter. A device interface adapter
+						is a custom software developed for each specific type of hardware.
+						In an application servient, on the other hand, a S-LCM obtains TDs
+						by getting one from location advertised by other servients or
+						requesting other servients of TDs, and creates a ConsumedThing
+						based on the obtained TD. Functions of an application servient are
+						usually implemented as an application. The abstract interface of a
+						ConsumedThing is provided as a programming language (such as
+						JavaScript) interface, and the application achieves its functions
+						by using this interface.</p>
+					<figure id="simple-conf-application-device">
+						<img src="images/arch-simple-conf-application-device.png" />
+						<figcaption>Simple configuration of application and
+							device</figcaption>
+					</figure>
+				</section>
+				<section>
+					<h3>Inter connection with Proxy Servient</h3>
+					<p>Next, inner structure of a servient is explained based on the
+						structure of a proxy servient that connects a device servient and
+						application servient together.</p>
+					<p>A runtime in a proxy servient has both ExposedThing and
+						ConsumedThing functionality. A S-LCM, similar to that of an
+						application servient, obtains a TD of a device servient, and
+						creates a ConsumedThing. At the same time, a S-LCM creates a shadow
+						of the device as well as a TD for the shadow device where the
+						identifier is a new one and protocol bindings are appropriately
+						described to serve for the application. An ExposedThing is created
+						based on this TD, and a S-LCM notifies other servients of the TD.</p>
+					<figure id="simple-conf-application-proxy-device">
+						<img src="images/arch-simple-conf-application-proxy-device.png" />
+						<figcaption>Simple configuration with proxy</figcaption>
+					</figure>
+				</section>
+			</section>
+	
 	</section>
 	<section id="sec-security-considerations">
 		<h1>Security and Privacy Considerations</h1>
@@ -2617,10 +2628,8 @@ a[href].internalDFN {
 					binding.</p>
 				<p>
 					<img src="images/message-flows/A_3_1c_eventWebSocket.png"
-						alt="Subscribe,               notify and unsubscribe event (binding = simple WebSocket)" />
-				</p>
-			</section>
-		</section>
+						alt="Subscribe,               
+						
 	</section>
 	<section class="appendix">
 		<h1>SNIPPETS: (was WoT Deployment Scenarios and Guidelines)</h1>

--- a/index.html
+++ b/index.html
@@ -2643,7 +2643,10 @@ a[href].internalDFN {
 				<p>
 					<img src="images/message-flows/A_3_1c_eventWebSocket.png"
 						alt="Subscribe,               
-						
+						notify and unsubscribe event (binding = simple WebSocket)" />          
+				</p>							
+			</section>	
+		</section>
 	</section>
 	<section class="appendix">
 		<h1>SNIPPETS: (was WoT Deployment Scenarios and Guidelines)</h1>

--- a/index.html
+++ b/index.html
@@ -291,15 +291,15 @@ a[href].internalDFN {
 				software object for the application in the local runtime
 				environment.</dd>
 			<dt>
-				<dt>
-					<dfn>CoAP</dfn>
-				</dt>
-				<dd>Acronym for Constrained Application Protocol [[RFC7252]]</dd>
-				<dt>
-					<dfn>CWT</dfn>
-				</dt>
-				<dd>CBOR Web Token</dd>
-					<dfn>Consumed Thing</dfn>
+			<dt>
+				<dfn>CoAP</dfn>
+			</dt>
+			<dd>Acronym for Constrained Application Protocol [[RFC7252]]</dd>
+			<dt>
+				<dfn>CWT</dfn>
+			</dt>
+			<dd>CBOR Web Token</dd>
+			<dfn>Consumed Thing</dfn>
 			</dt>
 			<dd>A software object instance created through the WoT object of
 				the Scripting API that represents a remote Thing used by the local
@@ -347,21 +347,21 @@ a[href].internalDFN {
 				that is implemented locally and can be accessed over the network by
 				remote WoT Clients. It is defined by the ExposedThing interface of
 				the WoT Scripting API.</dd>
-				<dt>
-						<dfn>Hypermedia Controls</dfn>
-					</dt>
-					<dd><i>Hypermedia controls</i> are request templates, 
-						which can be seen as forms to fill in and to send to servers.
-					</dd>
-				<dt>
+			<dt>
+				<dfn>Hypermedia Controls</dfn>
+			</dt>
+			<dd>
+				<i>Hypermedia controls</i> are request templates, which can be seen
+				as forms to fill in and to send to servers.
+			</dd>
+			<dt>
 				<dfn>Interaction Affordance</dfn>
 			</dt>
-			<dd>Metadata of a Thing exposing hypermedia controls that describe the 
-					possible protocol-level choices to clients, thereby suggesting how 
-					clients may interact with the Thing. 
-					Examples of affordances include, but are not limited to getting and 
-					setting properties, invoking actions, and subscribing to events.	
-					</dd>
+			<dd>Metadata of a Thing exposing hypermedia controls that
+				describe the possible protocol-level choices to clients, thereby
+				suggesting how clients may interact with the Thing. Examples of
+				affordances include, but are not limited to getting and setting
+				properties, invoking actions, and subscribing to events.</dd>
 			<dt>
 				<dfn>Interaction Model</dfn>
 			</dt>
@@ -374,20 +374,20 @@ a[href].internalDFN {
 			<dd>A specific IoT ecosystem such as OCF, oneM2M, or Mozilla
 				Project Things with its own specifications for application-facing
 				APIs, data model, and protocols or protocol configurations.</dd>
-				<dt>
-					<dfn>JSON-LD</dfn>
-				</dt>
-				<dd>
-					A JSON document that is augmented with support for Linked Data by
-					providing an
-					<code>@context</code>
-					property with a defining URI [[json-ld]].
-				</dd>
-				<dt>
-					<dfn>JWT</dfn>
-				</dt>
-				<dd>JSON Web Token [[RFC7519]]</dd>
-				<dt>
+			<dt>
+				<dfn>JSON-LD</dfn>
+			</dt>
+			<dd>
+				A JSON document that is augmented with support for Linked Data by
+				providing an
+				<code>@context</code>
+				property with a defining URI [[json-ld]].
+			</dd>
+			<dt>
+				<dfn>JWT</dfn>
+			</dt>
+			<dd>JSON Web Token [[RFC7519]]</dd>
+			<dt>
 				<dfn>Local Discovery</dfn>
 			</dt>
 			<dd>A discovery method that can discover Things directly
@@ -401,11 +401,13 @@ a[href].internalDFN {
 				or hard-coding in a script).</dd>
 			<dt>
 				<dfn>MQTT</dfn>
-					<dd> <i>Message Queuing Telemetry Transport</i> is a publish-subscribe-based 
-						messaging protocol.[[!MQTT]] </dd>
+			<dd>
+				<i>Message Queuing Telemetry Transport</i> is a
+				publish-subscribe-based messaging protocol.[[!MQTT]]
+			</dd>
 
 
-				<dfn>Nearby Discovery</dfn>
+			<dfn>Nearby Discovery</dfn>
 			</dt>
 			<dd>A discovery method where the physical location is considered
 				(e.g., BLE, Audio Watermarking, ...).</dd>
@@ -425,15 +427,15 @@ a[href].internalDFN {
 				<dfn data-lt="WoT Protocol Binding">Protocol Binding</dfn>
 			</dt>
 			<dd>The set of mapping rules from an Interaction Affordance to
-				concrete messages of a specific protocol. 
-				These rules are encoded into the TD using forms.</dd>
+				concrete messages of a specific protocol. These rules are encoded
+				into the TD using forms.</dd>
 			<dt>
-				<dt>
-					<dfn>RDF</dfn>
-				</dt>
-				<dd>The Resource Description Framework (RDF) of the Semantic Web
-					[[rdf-concepts]]</dd>
-					<dfn>Remote Discovery</dfn>
+			<dt>
+				<dfn>RDF</dfn>
+			</dt>
+			<dd>The Resource Description Framework (RDF) of the Semantic Web
+				[[rdf-concepts]]</dd>
+			<dfn>Remote Discovery</dfn>
 			</dt>
 			<dd>A discovery method which supports lookup of remote Things
 				also beyond network boundaries, for instance by using a directory
@@ -490,11 +492,12 @@ a[href].internalDFN {
 			</dt>
 			<dd>The underlying, standardized application layer protocol
 				without application-specific options or subprotocol mechanisms.</dd>
-				<dt>
-					<dfn>WoT</dfn>
-				</dt>
-				<dd>The Web of Things initiative and family of specifications in the W3C.</dd>
-				<dt>
+			<dt>
+				<dfn>WoT</dfn>
+			</dt>
+			<dd>The Web of Things initiative and family of specifications in
+				the W3C.</dd>
+			<dt>
 				<dfn>WoT Client</dfn>
 			</dt>
 			<dd>An entity that can connect with a network interface
@@ -504,9 +507,10 @@ a[href].internalDFN {
 			<dt>
 				<dfn>WoT Interface</dfn>
 			</dt>
-			<dd>The WoT Interface is the network-facing interface that is described by a TD. 
-				This requires the mapping rules of Protocol Bindings between the abstract 
-				WoT Runtime (Thing level) to a network-facing interface (protocol level).</dd>
+			<dd>The WoT Interface is the network-facing interface that is
+				described by a TD. This requires the mapping rules of Protocol
+				Bindings between the abstract WoT Runtime (Thing level) to a
+				network-facing interface (protocol level).</dd>
 			<dt>
 				<dfn>WoT Object</dfn>
 			</dt>
@@ -518,19 +522,18 @@ a[href].internalDFN {
 			</dt>
 			<dd>A runtime system for application scripts with the WoT
 				Scripting API. Implementing a WoT Runtime is optional for Servients.
-			
-				The WoT Runtime should be the component that instantiates 
-				Consumed Things and Exposed Things as software objects, 
-				manages their state, and generates the TDs. 
-				It communicates with other components such as the Binding implementations 
-				and application scripts (the WoT Scripting API being one way).</dd>
-				<dt>
-						<dfn data-lt="WoT Scripting API">Scripting API</dfn>
-					</dt>
-					<dd>The application-facing programming interface provided by a
-						Servient; comparable to the Web browser APIs. It is an API 
-						provided to ease the implementation of, 
-						or to extend a WoT Runtime.</dd>
+
+				The WoT Runtime should be the component that instantiates Consumed
+				Things and Exposed Things as software objects, manages their state,
+				and generates the TDs. It communicates with other components such as
+				the Binding implementations and application scripts (the WoT
+				Scripting API being one way).</dd>
+			<dt>
+				<dfn data-lt="WoT Scripting API">Scripting API</dfn>
+			</dt>
+			<dd>The application-facing programming interface provided by a
+				Servient; comparable to the Web browser APIs. It is an API provided
+				to ease the implementation of, or to extend a WoT Runtime.</dd>
 			<dt>
 				<dfn>WoT Server</dfn>
 			</dt>
@@ -883,17 +886,17 @@ a[href].internalDFN {
 				<p>
 					The first use case is a local device controlled by user-operated
 					remote controller as depicted in <a href="#smart-home-device"></a>
-					. For example, A remote controller can access an electronic appliance through 
-					the local home network directly. In this case, the remote controller can be realized 
-					by a browser or native application.
+					. For example, A remote controller can access an electronic
+					appliance through the local home network directly. In this case,
+					the remote controller can be realized by a browser or native
+					application.
 				</p>
-				<p>
-					In this pattern, at least one device like the electronic appliance have a server role 
-					that can accept the request from the other devices and respond them, and sometimes start 
-					to initiate mechanical function of it. The another device like the remote controller 
-					have a client role that can issue a message to the other with some requests, like to get 
-					sensor value or to turn it on.
-				</p>
+				<p>In this pattern, at least one device like the electronic
+					appliance have a server role that can accept the request from the
+					other devices and respond them, and sometimes start to initiate
+					mechanical function of it. The another device like the remote
+					controller have a client role that can issue a message to the other
+					with some requests, like to get sensor value or to turn it on.</p>
 				<figure id="smart-home-device">
 					<img src="images/wot-use-cases/smart-home-device.png"
 						style="width: 500px;" />
@@ -904,15 +907,15 @@ a[href].internalDFN {
 				<h3>Thing-to-Thing</h3>
 				<p>
 					<a href="#smart-home-t2t"></a> shows an example of direct
-					Thing-to-Thing interaction. The scenario is as follows:
-					a sensor detects the change of the room condition, for example the temperature 
-					surpassing a set threshold, and issues a control message like "turn on" to the 
-					electronic appliance. The sensor unit can issue some trigger messages to other devices.
+					Thing-to-Thing interaction. The scenario is as follows: a sensor
+					detects the change of the room condition, for example the
+					temperature surpassing a set threshold, and issues a control
+					message like "turn on" to the electronic appliance. The sensor unit
+					can issue some trigger messages to other devices.
 				</p>
-				<p>
-					In this case, when two devices that have server roles are connected, at least one device 
-					must have also a client role that issues a message to the other to actuate.
-				</p>
+				<p>In this case, when two devices that have server roles are
+					connected, at least one device must have also a client role that
+					issues a message to the other to actuate.</p>
 				<figure id="smart-home-t2t">
 					<img src="images/wot-use-cases/smart-home-t2t.png"
 						style="width: 500px;" />
@@ -925,15 +928,15 @@ a[href].internalDFN {
 					access/control use case. Include changing uplink connectivity.</p>
 				<p>
 					The third use case is a mobile remote controller (e.g., on a
-					smartphone) as shown in <a href="#smart-home-multi"></a>. 
-					The remote controller can switch communication media between cellular network 
-					and home network such as Wi-Fi and Bluetooth. The controller choose the home 
-					network when it's at home, and the cellular while outside.
+					smartphone) as shown in <a href="#smart-home-multi"></a>. The
+					remote controller can switch communication media between cellular
+					network and home network such as Wi-Fi and Bluetooth. The
+					controller choose the home network when it's at home, and the
+					cellular while outside.
 				</p>
-				<p>
-					In this pattern, the remote controller and the electronic appliance have a client role 
-					and a server role respectively as the same as 3.2.1 device controllers.	
-				</p>
+				<p>In this pattern, the remote controller and the electronic
+					appliance have a client role and a server role respectively as the
+					same as 3.2.1 device controllers.</p>
 				<figure id="smart-home-multi">
 					<img src="images/wot-use-cases/smart-home-multi.png"
 						style="width: 500px;" />
@@ -946,17 +949,17 @@ a[href].internalDFN {
 					box/compute node use case.</p>
 				<p>
 					<a href="#smart-home-gateway"></a> shows a use case based on a
-					Smart Home gateway. A smart home gateway is placed between a home network 
-					and the Internet. The gateway manages electronic appliances inside the house 
-					and can receive commands from a remote controller over the Internet, e.g., 
-					from a smartphone as in the previous use case. It is also is a virtual representation 
-					of a device. The gateways sometimes are called the proxies.
+					Smart Home gateway. A smart home gateway is placed between a home
+					network and the Internet. The gateway manages electronic appliances
+					inside the house and can receive commands from a remote controller
+					over the Internet, e.g., from a smartphone as in the previous use
+					case. It is also is a virtual representation of a device. The
+					gateways sometimes are called the proxies.
 				</p>
-				<p>
-					In this pattern, the home gateway have both of client and server roles. That is, 
-					it can connect to the electronic appliance with the client role and to the remote 
-					controller with the server role.
-				</p>
+				<p>In this pattern, the home gateway have both of client and
+					server roles. That is, it can connect to the electronic appliance
+					with the client role and to the remote controller with the server
+					role.</p>
 				<figure id="smart-home-gateway">
 					<img src="images/wot-use-cases/smart-home-gateway.png"
 						style="width: 500px;" />
@@ -965,11 +968,12 @@ a[href].internalDFN {
 			</section>
 			<section>
 				<h3>Digital Twins</h3>
-				<p>A digital twin is a virtual representation, i.e. a model of a device or a
-					group of devices that resides on a cloud server or edge device. It
-					can be used to represent real-world devices which may not be
-					continuously online, or to run simulations of new applications and
-					services, before they get deployed to the real devices.</p>
+				<p>A digital twin is a virtual representation, i.e. a model of a
+					device or a group of devices that resides on a cloud server or edge
+					device. It can be used to represent real-world devices which may
+					not be continuously online, or to run simulations of new
+					applications and services, before they get deployed to the real
+					devices.</p>
 				<figure id="digital-twin">
 					<img src="images/wot-use-cases/digital-twin.png"
 						style="width: 500px;" />
@@ -984,9 +988,9 @@ a[href].internalDFN {
 					<figcaption>Digital Twin for Multiple Devices</figcaption>
 				</figure>
 
-				<p>Digital twins can be realized in different ways, depending on whether a device
-				is already connected to the cloud, or whether it is connected to a gateway,
-				which itself is connected to the cloud.</p>
+				<p>Digital twins can be realized in different ways, depending on
+					whether a device is already connected to the cloud, or whether it
+					is connected to a gateway, which itself is connected to the cloud.</p>
 				<section>
 					<h4>Cloud-ready Devices</h4>
 					<p>
@@ -1035,22 +1039,20 @@ a[href].internalDFN {
 
 			<section>
 				<h3>Multi-Cloud</h3>
-				<p>
-					Typical IoT deployments consist of multiple (thousands) of devices.
-					Without a standardized mechanism, the management of firmware updates 
-					for specific clouds require a lot of effort and hinders wider scale IoT adoption.
-				</p>
-				<p>The primary benefit of a standardized mechanism for describing				
-					devices and device types is the capability of deploying devices to
-					different cloud environments without the need of doing
+				<p>Typical IoT deployments consist of multiple (thousands) of
+					devices. Without a standardized mechanism, the management of
+					firmware updates for specific clouds require a lot of effort and
+					hinders wider scale IoT adoption.</p>
+				<p>The primary benefit of a standardized mechanism for
+					describing devices and device types is the capability of deploying
+					devices to different cloud environments without the need of doing
 					customization at device software / firmware level, i.e. installing
 					cloud specific code to a device. This implies that the solution is
 					flexible enough to describe devices in a way that allows
 					on-boarding and using devices in multiple IoT cloud environments.</p>
-				<p>
-					This drives adoption of Web of Things devices, since it enables easy
-					usage of new devices in an existing deployment, as well as 
-					migration of existing devices from one cloud to the other.
+				<p>This drives adoption of Web of Things devices, since it
+					enables easy usage of new devices in an existing deployment, as
+					well as migration of existing devices from one cloud to the other.
 				</p>
 			</section>
 
@@ -1324,27 +1326,28 @@ a[href].internalDFN {
 			</section>
 			<section>
 				<h3>Twins</h3>
-				<p>Twins need to generate program interfaces internally based
-					on device descriptions (i.e. TD), and to represent virtual devices
-					by using those program interfaces. A twin has to produce a TD
-					for the virtual device and make it externally available.</p>
+				<p>Twins need to generate program interfaces internally based on
+					device descriptions (i.e. TD), and to represent virtual devices by
+					using those program interfaces. A twin has to produce a TD for the
+					virtual device and make it externally available.</p>
 				<p>Identifiers of virtual devices need to be newly assigned,
 					therefore, are different from the original devices. This makes sure
 					that virtual devices and the original devices are clearly
 					recognized as separate entities. Transport and security mechanisms
 					and settings of the virtual devices can be different from original
-					devices if necessary. Virtual devices are required to have TDs provided
-					either directly by the twin or to have them available at external locations.
-					In either case it is required to make the TDs available so that other components can find
-					and use the devices associated with them.</p>
+					devices if necessary. Virtual devices are required to have TDs
+					provided either directly by the twin or to have them available at
+					external locations. In either case it is required to make the TDs
+					available so that other components can find and use the devices
+					associated with them.</p>
 			</section>
 			<section>
 				<h3>Discovery</h3>
 				<p>For TDs of devices and virtual devices to be accessible from
-					devices, applications and twins, there needs to be a common way
-					to share TDs. Directories can serve this requirement by providing
-					functionalities to allow devices and twins themselves
-					automatically or the users to manually register the descriptions.</p>
+					devices, applications and twins, there needs to be a common way to
+					share TDs. Directories can serve this requirement by providing
+					functionalities to allow devices and twins themselves automatically
+					or the users to manually register the descriptions.</p>
 				<p>Descriptions of the devices and virtual devices need to be
 					searchable by external entities. Directories have to be able to
 					process search operations with search keys such as keywords from
@@ -1406,11 +1409,10 @@ a[href].internalDFN {
 				exchange messages.</p>
 			<p>Next, in the below configuration, an application and a device
 				connect to each other via a proxy.</p>
-				<section class="ednote">
-				<p>
-				Need to adapt this chapter to use digital twin terminology instead of proxy.
-				</p>
-				</section>
+			<section class="ednote">
+				<p>Need to adapt this chapter to use digital twin terminology
+					instead of proxy.</p>
+			</section>
 			<figure id="high-level-application-proxy-device">
 				<img src="images/arch-high-level-application-proxy-device.png" />
 				<figcaption>High level architecture with proxy</figcaption>
@@ -2300,63 +2302,63 @@ a[href].internalDFN {
 			</figure>
 		</section>
 		<section>
-				<h3>Inter Connection of Servients</h3>
-				<p>This section describes below how to inter connect among the
-					servients.</p>
-	
-				<section>
-					<h3>Inter connection between application and device servients</h3>
-					<p>First, inner structure of a servient is explained based on
-						the structure of an application servient and a device servient. WoT
-						runtime defines an abstract interface that contains methods such as
-						READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
-						devices. When a servient communicates over a network, those methods
-						are bound to concrete protocols. For example, in the case of HTTP,
-						HTTP methods such as PUT and GET are assigned to implement the
-						abstract methods. WoT clients can retrieve and change device
-						settings or device attributes defined in TDs through those abstract
-						methods. In a device servient, WoT Servient Life Cycle Management
-						(S-LCM) creates an ExposedThing based on TD. S-LCM also advertises
-						a TD to other servients, or provides other servients with a TD upon
-						request. A device servient's functions are usually implemented as
-						hardware, and those functions are accessible through its firmware.
-						An ExposedThing's abstract interface is translated into hardware
-						commands by a device interface adapter. A device interface adapter
-						is a custom software developed for each specific type of hardware.
-						In an application servient, on the other hand, a S-LCM obtains TDs
-						by getting one from location advertised by other servients or
-						requesting other servients of TDs, and creates a ConsumedThing
-						based on the obtained TD. Functions of an application servient are
-						usually implemented as an application. The abstract interface of a
-						ConsumedThing is provided as a programming language (such as
-						JavaScript) interface, and the application achieves its functions
-						by using this interface.</p>
-					<figure id="simple-conf-application-device">
-						<img src="images/arch-simple-conf-application-device.png" />
-						<figcaption>Simple configuration of application and
-							device</figcaption>
-					</figure>
-				</section>
-				<section>
-					<h3>Inter connection with Proxy Servient</h3>
-					<p>Next, inner structure of a servient is explained based on the
-						structure of a proxy servient that connects a device servient and
-						application servient together.</p>
-					<p>A runtime in a proxy servient has both ExposedThing and
-						ConsumedThing functionality. A S-LCM, similar to that of an
-						application servient, obtains a TD of a device servient, and
-						creates a ConsumedThing. At the same time, a S-LCM creates a shadow
-						of the device as well as a TD for the shadow device where the
-						identifier is a new one and protocol bindings are appropriately
-						described to serve for the application. An ExposedThing is created
-						based on this TD, and a S-LCM notifies other servients of the TD.</p>
-					<figure id="simple-conf-application-proxy-device">
-						<img src="images/arch-simple-conf-application-proxy-device.png" />
-						<figcaption>Simple configuration with proxy</figcaption>
-					</figure>
-				</section>
+			<h3>Inter Connection of Servients</h3>
+			<p>This section describes below how to inter connect among the
+				servients.</p>
+
+			<section>
+				<h3>Inter connection between application and device servients</h3>
+				<p>First, inner structure of a servient is explained based on
+					the structure of an application servient and a device servient. WoT
+					runtime defines an abstract interface that contains methods such as
+					READ, WRITE, INVOKE, SUBSCRIBE, NOTIFY through which to access
+					devices. When a servient communicates over a network, those methods
+					are bound to concrete protocols. For example, in the case of HTTP,
+					HTTP methods such as PUT and GET are assigned to implement the
+					abstract methods. WoT clients can retrieve and change device
+					settings or device attributes defined in TDs through those abstract
+					methods. In a device servient, WoT Servient Life Cycle Management
+					(S-LCM) creates an ExposedThing based on TD. S-LCM also advertises
+					a TD to other servients, or provides other servients with a TD upon
+					request. A device servient's functions are usually implemented as
+					hardware, and those functions are accessible through its firmware.
+					An ExposedThing's abstract interface is translated into hardware
+					commands by a device interface adapter. A device interface adapter
+					is a custom software developed for each specific type of hardware.
+					In an application servient, on the other hand, a S-LCM obtains TDs
+					by getting one from location advertised by other servients or
+					requesting other servients of TDs, and creates a ConsumedThing
+					based on the obtained TD. Functions of an application servient are
+					usually implemented as an application. The abstract interface of a
+					ConsumedThing is provided as a programming language (such as
+					JavaScript) interface, and the application achieves its functions
+					by using this interface.</p>
+				<figure id="simple-conf-application-device">
+					<img src="images/arch-simple-conf-application-device.png" />
+					<figcaption>Simple configuration of application and
+						device</figcaption>
+				</figure>
 			</section>
-	
+			<section>
+				<h3>Inter connection with Proxy Servient</h3>
+				<p>Next, inner structure of a servient is explained based on the
+					structure of a proxy servient that connects a device servient and
+					application servient together.</p>
+				<p>A runtime in a proxy servient has both ExposedThing and
+					ConsumedThing functionality. A S-LCM, similar to that of an
+					application servient, obtains a TD of a device servient, and
+					creates a ConsumedThing. At the same time, a S-LCM creates a shadow
+					of the device as well as a TD for the shadow device where the
+					identifier is a new one and protocol bindings are appropriately
+					described to serve for the application. An ExposedThing is created
+					based on this TD, and a S-LCM notifies other servients of the TD.</p>
+				<figure id="simple-conf-application-proxy-device">
+					<img src="images/arch-simple-conf-application-proxy-device.png" />
+					<figcaption>Simple configuration with proxy</figcaption>
+				</figure>
+			</section>
+		</section>
+
 	</section>
 	<section id="sec-security-considerations">
 		<h1>Security and Privacy Considerations</h1>
@@ -2643,9 +2645,9 @@ a[href].internalDFN {
 				<p>
 					<img src="images/message-flows/A_3_1c_eventWebSocket.png"
 						alt="Subscribe,               
-						notify and unsubscribe event (binding = simple WebSocket)" />          
-				</p>							
-			</section>	
+						notify and unsubscribe event (binding = simple WebSocket)" />
+				</p>
+			</section>
 		</section>
 	</section>
 	<section class="appendix">

--- a/index.html
+++ b/index.html
@@ -347,11 +347,21 @@ a[href].internalDFN {
 				that is implemented locally and can be accessed over the network by
 				remote WoT Clients. It is defined by the ExposedThing interface of
 				the WoT Scripting API.</dd>
-			<dt>
+				<dt>
+						<dfn>Hypermedia Controls</dfn>
+					</dt>
+					<dd><i>Hypermedia controls</i> are request templates, 
+						which can be seen as forms to fill in and to send to servers.
+					</dd>
+				<dt>
 				<dfn>Interaction Affordance</dfn>
 			</dt>
-			<dd>Metadata of a Thing that shows the possible choices to
-				clients, thereby suggesting how clients may interact with the Thing.</dd>
+			<dd>Metadata of a Thing exposing hypermedia controls that describe the 
+					possible protocol-level choices to clients, thereby suggesting how 
+					clients may interact with the Thing. 
+					Examples of affordances include, but are not limited to getting and 
+					setting properties, invoking actions, and subscribing to events.	
+					</dd>
 			<dt>
 				<dfn>Interaction Model</dfn>
 			</dt>
@@ -415,7 +425,8 @@ a[href].internalDFN {
 				<dfn data-lt="WoT Protocol Binding">Protocol Binding</dfn>
 			</dt>
 			<dd>The set of mapping rules from an Interaction Affordance to
-				concrete messages of a specific protocol.</dd>
+				concrete messages of a specific protocol. 
+				These rules are encoded into the TD using forms.</dd>
 			<dt>
 				<dt>
 					<dfn>RDF</dfn>
@@ -427,11 +438,6 @@ a[href].internalDFN {
 			<dd>A discovery method which supports lookup of remote Things
 				also beyond network boundaries, for instance by using a directory
 				service. The endpoint of the directory must be supported.</dd>
-			<dt>
-				<dfn data-lt="WoT Scripting API">Scripting API</dfn>
-			</dt>
-			<dd>The application-facing programming interface provided by a
-				Servient; comparable to the Web browser APIs.</dd>
 			<dt>
 				<dfn>Server API</dfn>
 			</dt>
@@ -487,7 +493,7 @@ a[href].internalDFN {
 				<dt>
 					<dfn>WoT</dfn>
 				</dt>
-				<dd>The Web of Things initiatiove in the W3C.</dd>
+				<dd>The Web of Things initiative and family of specifications in the W3C.</dd>
 				<dt>
 				<dfn>WoT Client</dfn>
 			</dt>
@@ -498,8 +504,9 @@ a[href].internalDFN {
 			<dt>
 				<dfn>WoT Interface</dfn>
 			</dt>
-			<dd>The network-facing interface of a Thing as defined by its
-				Thing Description.</dd>
+			<dd>The WoT Interface is the network-facing interface that is described by a TD. 
+				This requires the mapping rules of Protocol Bindings between the abstract 
+				WoT Runtime (Thing level) to a network-facing interface (protocol level).</dd>
 			<dt>
 				<dfn>WoT Object</dfn>
 			</dt>
@@ -517,6 +524,13 @@ a[href].internalDFN {
 				manages their state, and generates the TDs. 
 				It communicates with other components such as the Binding implementations 
 				and application scripts (the WoT Scripting API being one way).</dd>
+				<dt>
+						<dfn data-lt="WoT Scripting API">Scripting API</dfn>
+					</dt>
+					<dd>The application-facing programming interface provided by a
+						Servient; comparable to the Web browser APIs. It is an API 
+						provided to ease the implementation of, 
+						or to extend a WoT Runtime.</dd>
 			<dt>
 				<dfn>WoT Server</dfn>
 			</dt>


### PR DESCRIPTION
cleanup terminology
https://github.com/w3c/wot-architecture/issues/83
moving chapter 7.5 Interconnection of servients to chapter "9 WoT Deployments"
https://github.com/w3c/wot-architecture/issues/110