### PR TITLE
[Editorial] fix for Use Case section

### DIFF
--- a/index.html
+++ b/index.html
@@ -755,7 +755,7 @@ a[href].internalDFN {
 				with notifications of an early warning system for critical road and
 				traffic conditions.</p>
 			<section id="connected car example">
-				<h4 id="connectedcar">Connected Car Example</h4>
+				<h4 id="connectedcar-example">Connected Car Example</h4>
 				<p>
 					<a href="#connected-car"></a> shows an example of a Connected Car.
 					In this case, a gateway connects to car components through CAN and
@@ -778,7 +778,6 @@ a[href].internalDFN {
 				traffic conditions.</p>
 		</section>
 
-	</section>
 	<section id="commonusecasespatterns">
 		<h1>Common Patterns</h1>
 		<section>
@@ -910,6 +909,7 @@ a[href].internalDFN {
 			</section>
 			<section>
 				<h3>Legacy Devices</h3>
+				<p>
 				<a href="#smart-home-cloud2"></a> shows an example where legacy
 				electronic appliances cannot directly connect to the cloud. Here, a
 				gateway is needed to relay the connection. The gateway works as:

--- a/index.html
+++ b/index.html
@@ -701,7 +701,7 @@ a[href].internalDFN {
 					security hazards. Monitoring of assets at construction site can
 					prevent damage and loss.</p>
 			</section>
-		</section>
+
 		<section id="sec-agriculture">
 			<h3 id="agriculture">Agriculture</h3>
 			<p>Soil condition monitoring and creating optimal plans for
@@ -777,7 +777,7 @@ a[href].internalDFN {
 				with notifications of an early warning system for critical road and
 				traffic conditions.</p>
 		</section>
-
+  </section>
 	<section id="commonusecasespatterns">
 		<h1>Common Patterns</h1>
 		<section>


### PR DESCRIPTION
Section structure in Use Case section is broken.  It cause section numbering change on later section, and it may cause confusion on discussions.
- [Agriculture](https://w3c.github.io/wot-architecture/#sec-agriculture) and other application domain: 4.x -> should be 4.1.y
- [Common Patterns](https://w3c.github.io/wot-architecture/#commonusecasespatterns): 5. -> should be 4.2
- [Summary](https://w3c.github.io/wot-architecture/#summary): 6 -> should be 4.3
 
and also I fix some minor problem:
- duplicated id for Connected Car section
- missing `<p>` on Legacy Devices section