### PR TITLE
Remove Section 6.1 Overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -1347,13 +1347,6 @@ a					general metadata about the device, information models representing
 			<em>This section is normative.</em>
 		</p>
 		
-		<section id="sec-architecture-overview">
-			<h2>Overview</h2>
-			<figure id="architecture-abstract">
-				<img src="images/architecture-abstract.png" style="width: 100%;" />
-				<figcaption>Abstract Architecture of W3C WoT</figcaption>
-			</figure>
-		</section>
 		<section id="sec-WoT-servient-architecture-high-level">
 			<h2>High-level architecture</h2>
 			<p>Overview of WoT component’s behavior is explained using a


### PR DESCRIPTION
As discussed before, removed Figure "Abstract Architecture" in Section 6.1. Because this figure is duplicated to Figure "User Case Overview" in Section 4.3