### PR TITLE
TAG submission documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,146 +7,146 @@
 <script class="remove"
     src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
 <script class="remove">
-	var respecConfig = {
-		specStatus : "ED",
-		processVersion : 2017,
-		shortName : "wot-architecture",
-		copyrightStart : 2017,
-		wg : "Web of Things Working Group",
-		wgURI : "https://www.w3.org/WoT/WG/",
-		wgPublicList : "public-wot-wg",
-		edDraftURI : "https://w3c.github.io/wot-architecture/",
-		githubAPI : "https://api.github.com/repos/w3c/wot-architecture",
-		issueBase : "https://www.github.com/w3c/wot-architecture/issues",
-		editors : [ {
-			name : "Matthias Kovatsch",
-			w3cid : "75998",
-			company : "Huawei",
-			companyURL : "https://www.huawei.com/"
-		}, {
-			name : "Kazuo Kajimoto",
-			w3cid : "74112",
-			company : "Panasonic Corp.",
-			companyURL : "https://www.panasonic.com/"
-		}, {
-			name : "Ryuichi Matsukura",
-			w3cid : "64284",
-			company : "Fujitsu Ltd.",
-			companyURL : "https://www.fujitsu.com/"
-		}, {
-			name : "Michael Lagally",
-			w3cid : "47166",
-			company : "Oracle Corp.",
-			companyURL : "https://www.oracle.com/"
-		}, {
-			name : "Toru Kawaguchi",
-			w3cid : "79307",
-			company : "Panasonic Corp.",
-			companyURL : "https://www.panasonic.com/"
-		} ],
-		otherLinks : [
-				{
-					key : "Contributors",
-					data : [ {
-						value : "In the GitHub repository",
-						href : "https://github.com/w3c/wot-architecture/graphs/contributors"
-					} ]
-				}, {
-					key : "Repository",
-					data : [ {
-						value : "We are on GitHub",
-						href : "https://github.com/w3c/wot-architecture/"
-					}, {
-						value : "File a bug",
-						href : "https://github.com/w3c/wot-architecture/issues"
-					} ]
-				} ],
-		localBiblio : {
-			"CoRE-RD" : {
-				href : "https://tools.ietf.org/html/draft-ietf-core-resource-directory-11",
-				title : "CoRE Resource Directory",
-				status : "Internet-Draft",
-				publisher : "IETF",
-				date : "03 July 2017"
-			},
-			"WOT-SECURITY-CONSIDERATIONS" : {
-				href : "https://www.w3.org/TR/wot-security/",
-				title : "Web of Things Security and Privacy Considerations",
-				publisher : "W3C"
-			},
-			"WOT-SECURITY-BEST-PRACTICES" : {
-				href : "https://www.w3.org/TR/wot-security-best-practices/",
-				title : "Web of Things Security Best Practices",
-				publisher : "W3C"
-			},
-			"WOT-SECURITY-TESTING-PLAN" : {
-				href : "https://www.w3.org/TR/wot-security-testing-plan/",
-				title : "Web of Things Security Best Practices",
-				publisher : "W3C"
-			},
-			"IEC-FOTF" : {
-				href : "https://www.iec.ch/whitepaper/pdf/iecWP-futurefactory-LR-en.pdf",
-				title : "Factory of the future",
-				publisher : "IEC",
-				date : "October 2015"
-			},
-			"iot-schema-org" : {
-				href : "https://iot.schema.org/",
-				title : "iot.schema.org"
-			},
-			"REST" : {
-				title : "REST: Architectural Styles and the Design of Network-based Software Architectures",
-				author : "Roy Thomas Fielding",
-				status : "PhD thesis",
-				publisher : "University of California, Irvine",
-				date : "2000"
-			},
-			"SAREF" : {
-				href : "https://sites.google.com/site/smartappliancesproject/ontologies/reference-ontology",
-				title : "Smart Appliances REFerence (SAREF) ontology",
-				publisher : "ETSI",
-				date : "November 2015"
-			},
-			"SSN" : {
-				href : "https://www.w3.org/TR/vocab-ssn/",
-				title : "Semantic Sensor Ontology",
-				publisher : "W3C",
-				date : "October 2017"
-			},
-			"HMI" : {
-				title : "The Encyclopedia of Human-Computer Interaction, 2nd Ed",
-				author : "Mads Soegaard, Rikke Friis Dam",
-				publisher : "Interaction Design Foundation",
-				date : "2013"
-			},
-			"NORMAN" : {
-				title : "The Psychology of Everyday Things",
-				author : "Donald A. Norman",
-				publisher : "Basic Books",
-				date : "1988"
-			},
-			"MQTT" : {
-				title : "MQTT Version 3.1.1",
-				author : "Andrew Banks, Rahul Gupta",
-				publisher : "OASIS Standard",
-				date : "2014"
-			},
-			"FORMS" : {
-				href : "https://tools.ietf.org/html/draft-hartke-t2trg-coral",
-				title : "The Constrained RESTful Application Language (CoRAL)",
-				author : "Klaus Hartke",
-				publisher : "IETF",
-				status : "Internet-Draft",
-				date : "2019"
-			}
-		}
-	};
+        var respecConfig = {
+                specStatus : "ED",
+                processVersion : 2017,
+                shortName : "wot-architecture",
+                copyrightStart : 2017,
+                wg : "Web of Things Working Group",
+                wgURI : "https://www.w3.org/WoT/WG/",
+                wgPublicList : "public-wot-wg",
+                edDraftURI : "https://w3c.github.io/wot-architecture/",
+                githubAPI : "https://api.github.com/repos/w3c/wot-architecture",
+                issueBase : "https://www.github.com/w3c/wot-architecture/issues",
+                editors : [ {
+                        name : "Matthias Kovatsch",
+                        w3cid : "75998",
+                        company : "Huawei",
+                        companyURL : "https://www.huawei.com/"
+                }, {
+                        name : "Kazuo Kajimoto",
+                        w3cid : "74112",
+                        company : "Panasonic Corp.",
+                        companyURL : "https://www.panasonic.com/"
+                }, {
+                        name : "Ryuichi Matsukura",
+                        w3cid : "64284",
+                        company : "Fujitsu Ltd.",
+                        companyURL : "https://www.fujitsu.com/"
+                }, {
+                        name : "Michael Lagally",
+                        w3cid : "47166",
+                        company : "Oracle Corp.",
+                        companyURL : "https://www.oracle.com/"
+                }, {
+                        name : "Toru Kawaguchi",
+                        w3cid : "79307",
+                        company : "Panasonic Corp.",
+                        companyURL : "https://www.panasonic.com/"
+                } ],
+                otherLinks : [
+                                {
+                                        key : "Contributors",
+                                        data : [ {
+                                                value : "In the GitHub repository",
+                                                href : "https://github.com/w3c/wot-architecture/graphs/contributors"
+                                        } ]
+                                }, {
+                                        key : "Repository",
+                                        data : [ {
+                                                value : "We are on GitHub",
+                                                href : "https://github.com/w3c/wot-architecture/"
+                                        }, {
+                                                value : "File a bug",
+                                                href : "https://github.com/w3c/wot-architecture/issues"
+                                        } ]
+                                } ],
+                localBiblio : {
+                        "CoRE-RD" : {
+                                href : "https://tools.ietf.org/html/draft-ietf-core-resource-directory-11",
+                                title : "CoRE Resource Directory",
+                                status : "Internet-Draft",
+                                publisher : "IETF",
+                                date : "03 July 2017"
+                        },
+                        "WOT-SECURITY-CONSIDERATIONS" : {
+                                href : "https://www.w3.org/TR/wot-security/",
+                                title : "Web of Things Security and Privacy Considerations",
+                                publisher : "W3C"
+                        },
+                        "WOT-SECURITY-BEST-PRACTICES" : {
+                                href : "https://www.w3.org/TR/wot-security-best-practices/",
+                                title : "Web of Things Security Best Practices",
+                                publisher : "W3C"
+                        },
+                        "WOT-SECURITY-TESTING-PLAN" : {
+                                href : "https://www.w3.org/TR/wot-security-testing-plan/",
+                                title : "Web of Things Security Best Practices",
+                                publisher : "W3C"
+                        },
+                        "IEC-FOTF" : {
+                                href : "https://www.iec.ch/whitepaper/pdf/iecWP-futurefactory-LR-en.pdf",
+                                title : "Factory of the future",
+                                publisher : "IEC",
+                                date : "October 2015"
+                        },
+                        "iot-schema-org" : {
+                                href : "https://iot.schema.org/",
+                                title : "iot.schema.org"
+                        },
+                        "REST" : {
+                                title : "REST: Architectural Styles and the Design of Network-based Software Architectures",
+                                author : "Roy Thomas Fielding",
+                                status : "PhD thesis",
+                                publisher : "University of California, Irvine",
+                                date : "2000"
+                        },
+                        "SAREF" : {
+                                href : "https://sites.google.com/site/smartappliancesproject/ontologies/reference-ontology",
+                                title : "Smart Appliances REFerence (SAREF) ontology",
+                                publisher : "ETSI",
+                                date : "November 2015"
+                        },
+                        "SSN" : {
+                                href : "https://www.w3.org/TR/vocab-ssn/",
+                                title : "Semantic Sensor Ontology",
+                                publisher : "W3C",
+                                date : "October 2017"
+                        },
+                        "HMI" : {
+                                title : "The Encyclopedia of Human-Computer Interaction, 2nd Ed",
+                                author : "Mads Soegaard, Rikke Friis Dam",
+                                publisher : "Interaction Design Foundation",
+                                date : "2013"
+                        },
+                        "NORMAN" : {
+                                title : "The Psychology of Everyday Things",
+                                author : "Donald A. Norman",
+                                publisher : "Basic Books",
+                                date : "1988"
+                        },
+                        "MQTT" : {
+                                title : "MQTT Version 3.1.1",
+                                author : "Andrew Banks, Rahul Gupta",
+                                publisher : "OASIS Standard",
+                                date : "2014"
+                        },
+                        "FORMS" : {
+                                href : "https://tools.ietf.org/html/draft-hartke-t2trg-coral",
+                                title : "The Constrained RESTful Application Language (CoRAL)",
+                                author : "Klaus Hartke",
+                                publisher : "IETF",
+                                status : "Internet-Draft",
+                                date : "2019"
+                        }
+                }
+        };
 </script>
 <style type="text/css">
 a[href].internalDFN {
-	color: inherit;
-	border-bottom: 1px solid #99c;
-	text-decoration: none;
+        color: inherit;
+        border-bottom: 1px solid #99c;
+        text-decoration: none;
 }
 </style>
 </head>
@@ -634,15 +634,15 @@ a[href].internalDFN {
                 or more protocols, and maintains private security
                 metadata.</dd>
             <!-- OLD DEFINITION
-			<dd>A runtime system for applications supporting the 
+                        <dd>A runtime system for applications supporting the 
                                 implementation of WoT Thing behavior. 
                                 Implementing a WoT Runtime is optional for Servients but is 
                                 mandatory when the WoT Scripting API is used.
 
-				The WoT Runtime instantiates Consumed
-				Things and Exposed Things as software objects, manages their state,
-				and generates the TDs. It communicates with other components such as
-				the Binding implementations and application scripts or programs through
+                                The WoT Runtime instantiates Consumed
+                                Things and Exposed Things as software objects, manages their state,
+                                and generates the TDs. It communicates with other components such as
+                                the Binding implementations and application scripts or programs through
                                 an API, the WoT Scripting API being one instance of such an API.
                         </dd>
 -->
@@ -2269,20 +2269,20 @@ a[href].internalDFN {
             best practice.
         </p>
         <!--
-			It is also possible, as shown in <a
-				href="#arch-thing-foreign"></a>, to use preexisting
-			"brownfield" devices as WoT Things.
+                        It is also possible, as shown in <a
+                                href="#arch-thing-foreign"></a>, to use preexisting
+                        "brownfield" devices as WoT Things.
                         Such devices may not themselves be able to expose a TD.
                         In this cases, to allow other WoT things to use them,
                         it is necessary to supply a TD via some other
                         mechanism, for example via a directory service.
                         Such Things are generally only usable as WoT Servers since they
                         cannot consume TDs for other devices.
-		<figure id="arch-thing-foreign">
-			<img src="images/wot-thing-foreign.png" />
-			<figcaption>A pre-existing device provided with a Thing Description</figcaption>
-		</figure>
-		</p>
+                <figure id="arch-thing-foreign">
+                        <img src="images/wot-thing-foreign.png" />
+                        <figcaption>A pre-existing device provided with a Thing Description</figcaption>
+                </figure>
+                </p>
 -->
         <p>In the following sections we will provide additional
             information on each WoT Building Block: the WoT Thing
@@ -2528,8 +2528,8 @@ a[href].internalDFN {
         </p>
         <figure id="architecture-implementation">
             <!--
-			<img src="images/architecture-implementation.png"
-				style="width: 640px;" />
+                        <img src="images/architecture-implementation.png"
+                                style="width: 640px;" />
 -->
             <img src="images/wot-thing-scripting.png"
                 style="width: 640px;" />
@@ -2670,37 +2670,37 @@ a[href].internalDFN {
                 internal interface that includes functionality to
                 realize the lifecycle management of ExposedThings.</p>
             <!--
-			<p>
-				When a WoT Servient is an application or a proxy, the lifecycle
-				management of ConsumedThings are realized in the same manner as that
-				of ExposedThings. The WoT Runtime provides an interface to operate
-				on the interaction model. This interface is defined as an abstract
-				interface.
+                        <p>
+                                When a WoT Servient is an application or a proxy, the lifecycle
+                                management of ConsumedThings are realized in the same manner as that
+                                of ExposedThings. The WoT Runtime provides an interface to operate
+                                on the interaction model. This interface is defined as an abstract
+                                interface.
 
-				For this abstract interface to be used to interact with other WoT
-				Servients or Web Server/Clients in practice, concrete bindings to
-				underlying protocols need to be selected and used.
+                                For this abstract interface to be used to interact with other WoT
+                                Servients or Web Server/Clients in practice, concrete bindings to
+                                underlying protocols need to be selected and used.
                                 It is the REST
-				protocol that is most commonly used as the WoT interface on the Web.
-				Other protocols such as CoAP, MQTT and WebSocket are also commonly
-				used, and the protocol bindings enable the use of those protocols to
-				interact with other Web Servients and Web Servers/Clients.
-			</p>
-			<p>Note that Web Servers and Clients are "Web Objects" that can
-				directly interact with WoT Servients through the WoT interface even
-				though they are not designed on the WoT interaction model. The
-				overwhelming majority of existing sensors and devices are not
-				implemented as Web Objects. The Device interface adapter represents
-				the functionality to translate the native interface of those diverse
-				kind of devices to/from the Abstract interface. As for the
-				interfaces to existing devices, there are standards in each domain
-				such as Home, Building and Factory. Moreover, the standards adopted
-				by nations and even regions are often different, adding more
-				complexity. Although in the future a framework for native protocol
-				translation may be considered that eases the development of such
-				translation work, it is not in the scope of the current WoT charter,
-				therefore, the translation functionality is just called the "Device
-				interface adapter".</p>
+                                protocol that is most commonly used as the WoT interface on the Web.
+                                Other protocols such as CoAP, MQTT and WebSocket are also commonly
+                                used, and the protocol bindings enable the use of those protocols to
+                                interact with other Web Servients and Web Servers/Clients.
+                        </p>
+                        <p>Note that Web Servers and Clients are "Web Objects" that can
+                                directly interact with WoT Servients through the WoT interface even
+                                though they are not designed on the WoT interaction model. The
+                                overwhelming majority of existing sensors and devices are not
+                                implemented as Web Objects. The Device interface adapter represents
+                                the functionality to translate the native interface of those diverse
+                                kind of devices to/from the Abstract interface. As for the
+                                interfaces to existing devices, there are standards in each domain
+                                such as Home, Building and Factory. Moreover, the standards adopted
+                                by nations and even regions are often different, adding more
+                                complexity. Although in the future a framework for native protocol
+                                translation may be considered that eases the development of such
+                                translation work, it is not in the scope of the current WoT charter,
+                                therefore, the translation functionality is just called the "Device
+                                interface adapter".</p>
                           -->
         </section>
         <section>
@@ -2758,8 +2758,8 @@ a[href].internalDFN {
                 maintaining a consistent <a>WoT Interface</a>.
                 <!--
                                 The details of such
-				"System Things" are out of the scope of standardization at present,
-				although W3C WoT will document several informational examples.
+                                "System Things" are out of the scope of standardization at present,
+                                although W3C WoT will document several informational examples.
 -->
             </p>
             <p>
@@ -3425,7 +3425,7 @@ a[href].internalDFN {
                     <img
                         src="images/message-flows/A_3_1c_eventWebSocket.png"
                         alt="Subscribe,
-						notify and unsubscribe event (binding = simple WebSocket)" />
+                                                notify and unsubscribe event (binding = simple WebSocket)" />
                 </p>
             </section>
         </section>

--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -19,7 +19,7 @@ Further details (optional):
   [Additional schedule details and constraints](https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf)
   
   
-  - [X] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/master/proposals/WoT%20Architecture%20Security%20and%20Privacy.html).
+  - [X] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/master/proposals/security_and_privacy.md).
   - [X] I have reviewed the TAG's [API Design Principles](https://w3ctag.github.io/design-principles/)
 
 You should also know that...

--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -11,12 +11,12 @@ I'm requesting a TAG review of:
 Further details (optional):
 
   - Relevant time constraints or deadlines: 
-  * TAG review feedback expected by April 5th
-  * CR transition planned for April 9th
-     - in order to make June 25 deadline for REC
-     - end of WG charter is June 30
+     * TAG review feedback expected by April 5th
+     * CR transition planned for April 9th
+        - in order to make June 25 deadline for REC
+        - end of WG charter is June 30
   
-  [Additional schedule constraints](https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf)
+  [Additional schedule details and constraints](https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf)
   
   
   - [X] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/master/proposals/WoT%20Architecture%20Security%20and%20Privacy.html).
@@ -26,6 +26,7 @@ You should also know that...
 
 - The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security/) document provides extra discussion of security with an IoT focus.
 - The related [WoT Thing Description](https://github.com/w3c/wot-thing-description) document is being submitted for TAG review at the same time.
+    - Tests of implementations will be associated with this document
 - The [WoT Binding Templates](https://github.com/w3c/wot-binding-templates) non-REC track informative document describes an optional WoT building block.
 - The [WoT Scripting API](https://github.com/w3c/wot-binding-templates) non-REC track informative document describes an optional WoT building block.
 

--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -27,8 +27,8 @@ You should also know that...
 - The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security/) document provides extra discussion of security with an IoT focus.
 - The related [WoT Thing Description](https://github.com/w3c/wot-thing-description) document is being submitted for TAG review at the same time.
     - Tests of implementations will be associated with this document
-- The [WoT Binding Templates](https://github.com/w3c/wot-binding-templates) non-REC track informative document describes an optional WoT building block.
-- The [WoT Scripting API](https://github.com/w3c/wot-binding-templates) non-REC track informative document describes an optional WoT building block.
+- The [WoT Binding Templates](https://github.com/w3c/wot-binding-templates) informative WG note describing an optional WoT building block.
+- The [WoT Scripting API](https://github.com/w3c/wot-binding-templates) informative WG note describing an optional WoT building block.
 
 
 We'd prefer the TAG provide feedback as (please select one):

--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -12,17 +12,23 @@ Further details (optional):
 
   - Relevant time constraints or deadlines: 
   * TAG review feedback expected by April 5th
-  * CR transition April 9th
+  * CR transition planned for April 9th
+     - in order to make June 25 deadline for REC
+     - end of WG charter is June 30
   
-  Additional schedule: https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf
+  [Additional schedule constraints](https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf)
   
   
-  - [ ] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](url).
+  - [X] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/master/proposals/WoT%20Architecture%20Security%20and%20Privacy.html).
   - [X] I have reviewed the TAG's [API Design Principles](https://w3ctag.github.io/design-principles/)
 
 You should also know that...
 
-[please tell us anything you think is relevant to this review]
+- The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security/) document provides extra discussion of security with an IoT focus.
+- The related [WoT Thing Description](https://github.com/w3c/wot-thing-description) document is being submitted for TAG review at the same time.
+- The [WoT Binding Templates](https://github.com/w3c/wot-binding-templates) non-REC track informative document describes an optional WoT building block.
+- The [WoT Scripting API](https://github.com/w3c/wot-binding-templates) non-REC track informative document describes an optional WoT building block.
+
 
 We'd prefer the TAG provide feedback as (please select one):
 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -82,7 +82,7 @@ current mechanisms (cookies, etc).
 WoT Things can also act as clients, however, accessing
 web services and other WoT Things acting as servers.
 It is also possible that the same device could instantiate
-multiple WoT Runtimes.  However, there is noi explicit mechanism
+multiple WoT Runtimes.  However, there is no explicit mechanism
 for sharing state between such instances, and each instance
 can be considered a single origin.
 
@@ -140,28 +140,39 @@ However, a mechanism for loading new scripts is not defined
 and is currently considered to be out of scope.
 Our architecture assumes the scripts running inside a WoT Thing
 are trusted implementations provided by the manufacturer
-of the device and installed using a suitable OTA update
+of the device and installed using a suitable update
 mechanism; but this update mechanism is not defined in our
 architecture and is also currently considered to be out of scope.
 
 ### Does this specification allow an origin access to a user’s location?
 
-As noted above in the PII response, in theory a device
-location could be encoded in a WoT Thing Description using
-an extension vocabulary, and this could in some cases be
-associated with a user.
+As noted above in the PII response, a device
+location may be encoded in a WoT Thing Description using
+an extension vocabulary, 
+and this could in some cases such a device location could be
+associated with a user's location.
 Location information, however, is neither a standard nor
 a required part of the architecture.
+It is, however, common in institutional IoT applications,
+but in this case the devices are typically not
+associated with a particular user's location, and in fact
+placement of location information in the TD is useful
+mostly for devices installed in a static location.
 
 A manufacturer of a device could also define an
 interaction that returns the
 location of the device.
+This is more likely in dynamic location use cases.
 We do not provide constraints on this, since it is usually
 the _purpose_ of IoT devices to provide access to sensor data.
 
-However, we do provide mechanisms to control access to
+To mitigate this risk,
+we do provide mechanisms to control access to
 interactions and a manufacturer can use these to
-prevent accidental disclosure to unauthorized users.
+prevent accidental disclosure to unauthorized users,
+and recommend that these mechanisms be used when PII
+can be inferred from device information, this being one example
+of that.
 A user can also inspect the WoT Thing Description to
 determine whether the device returns location information,
 assuming the manufacturer has not obfuscated the purpose
@@ -195,12 +206,32 @@ to support via its exposed interactions (network API).
 
 Yes, as discussed above.  A WoT Thing can act as a gateway to 
 other WoT Things or to other non-IP protocols.
+In fact, access to other devices is one of the primary use cases of WoT.
 
 The situation is unavoidably more complex than the client-server
-architecture of broswers.  A better analogy than browsers
+architecture of browsers.  A better analogy than browsers
 would be the microservice architecture used by many web services.
 The WoT Architecture supports best practices there, such
 as Zero-Trust networks.
+
+However, to be more specific, here "origin" in the usual
+web meaning means content from a specific web server,
+and "access to other devices" would mean from the browser.
+In the WoT context, "origin" could be interpreted as 
+a WoT Server (WoT Thing in server role) and "browser" would
+be a WoT Client.  In that specific case, there is no
+way for an arbitrary server to force an arbitrary client
+to access another device.  The WoT Client is in control,
+initiates messages, and decides what to do with the
+responses.  Even if we reverse the roles, which is
+common in the IoT (IoT endpoint devices are often servers) a WoT Server
+is never forced to do what a WoT Client requests.
+
+That said, an "gateway" Servient might be developed by
+a manufacturer that allows broad access to other devices.
+In this case, such a gateway service should be protected
+by access controls (in the Zero-Trust approach, _every_ service
+uses access controls, encryption, and authentication).
 
 ### Does this specification allow an origin some measure of control over a user agent’s native UI? 
 
@@ -241,11 +272,29 @@ This concept is not applicable to the WoT context, as there is no user agent.
 
 ### Does this specification persist data to a user’s local device? 
 
-Potentially, as a WoT Thing may include interactions that
-support POST requests.  IoT devices can act like web servers that 
-can of course retain state posted to them.
+A WoT Thing may be either a client or server.  Therefore we 
+have to consider this question from both the client and server 
+point of view.
 
-Note that scripts cannot be sent, only data.  So devices
+A WoT Thing in a server role may support interactions that
+support POST requests.  Such can of course retain state posted to them.
+If this state is too general (for example, a property that allows
+a client to POST and GET arbitrary string data) and is not 
+protected with access controls, _and_ if the device can be 
+associated with a particular user, _and_ the network protocol
+allows accesses to be tied to physical location, then this is 
+a potential physical tracking risk.  However, providing access
+controls on interactions (which is strongly recommended for
+all personal devices) mitigates this issue.
+
+In the client role, a WoT Thing could be programmed to 
+retreive data provided by a server and then post it back to that
+server later.  This could also be enabled by a webhook pattern.
+This can be mitigated by establishing a trust relationship
+and providing explicit access controls between any pair of
+devices before allowing data to be exchanged.
+
+Note that scripts cannot be included in TDs, only data.  So devices
 always have local control over what data they retain.  WoT Things
 are never _forced_ to retain state and return it later.
 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -25,7 +25,7 @@ For "new" devices written from scratch to conform to the WoT specifications,
 we define a set of 
 [WoT Security Best Practices](https://github.com/w3c/wot-security-best-practices)
 which will be updated as necessary (for example, as the WoT is extended to new
-IoT protocols or security schemes via its built-in extension mechansisms).
+IoT protocols or security schemes via its built-in extension mechanisms).
 In addition, we define a general security testing procedure for WoT implementations in the
 [WoT Security Testing Plan](https://github.com/w3c/wot-security-testing-plan).
 
@@ -39,7 +39,7 @@ with an owner, then it may be possible to infer information about the
 owner.  For example, if they have a baby monitor, they may have a baby,
 are probably in a certain age range, and so forth.
 
-The WoT Thing Description (TD) also allows extensibility via the inclusion
+The WoT Thing Description (TD) also allows extension via the inclusion
 of custom vocabularies.  Although the WoT standard itself does not
 have any requirement for PII, it is possible an extension might.  We
 consider this aspect of PII inclusion to be out of scope.
@@ -254,8 +254,8 @@ in the WoT Thing Description) which is meant to be a unique ID
 In fact, some domains, such as medical devices in the US,
 have a legal requirement to support immutable identifiers.
 
-However, we suggest that the tracking risk this poses shold
-be mitigated, whenever possible (eg if not legally disallowed
+However, we suggest that the tracking risk this poses should
+be mitigated, whenever possible (e.g. if not legally disallowed
 as discussed above) by allowing such identifiers to be modified
 at least when the devices are reprovisioned.
 
@@ -288,7 +288,7 @@ controls on interactions (which is strongly recommended for
 all personal devices) mitigates this issue.
 
 In the client role, a WoT Thing could be programmed to 
-retreive data provided by a server and then post it back to that
+retrieve data provided by a server and then post it back to that
 server later.  This could also be enabled by a webhook pattern.
 This can be mitigated by establishing a trust relationship
 and providing explicit access controls between any pair of
@@ -303,7 +303,7 @@ are never _forced_ to retain state and return it later.
 Yes, as explained above.
 This section in the WoT Architecture document is fairly high-level
 however and meant to be a summary of the most important considerations.
-There are also sections in each WoT buliding block
+There are also sections in each WoT building block
 document and a more general document.
 
 ### Does this specification allow downgrading default security characteristics? 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -1,0 +1,77 @@
+# WoT Architecture Responses to Security and Privacy Questionnaire
+
+This document was prepared by the Web of Things Working Group,
+responding to the questions raised in the
+[Self-Review Questionnaire: Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/) 
+published by the W3C TAG 
+related to the 
+[WoT Architecture](https://github.com/w3c/wot-architecture) document.
+
+Please raise issues on the
+[WoT Architecture GitHub Issue page](https://github.com/w3c/wot-architecture/issues).
+
+## Background
+
+The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security)
+includes an extensive threat model,
+and considers both passive and active attacks to
+both data (payload transactions) and metadata (Thing Descriptions).
+It should be made clear however that the WoT is _descriptive_.
+WoT Thing Descriptions can be used to describe existing IoT devices.
+In this case the WoT
+is subject the same threats and mitigations as those devices.
+For "new" devices written from scratch to conform to the WoT specifications,
+we define a set of 
+[WoT Security Best Practices](https://github.com/w3c/wot-security-best-practices)
+which will be updated as necessary (for example, as the WoT is extended to new
+IoT protocols or security schemes via its built-in extension mechansisms).
+In addition, we define a general security testing procedure for WoT implementations in the
+[WoT Security Testing Plan](https://github.com/w3c/wot-security-testing-plan).
+
+## Does this specification deal with personally-identifiable information? 
+
+## Does this specification deal with high-value data? 
+
+## Does this specification introduce new state for an origin that persists across browsing sessions? 
+
+## Does this specification expose persistent, cross-origin state to the web? 
+
+## Does this specification expose any other data to an origin that it doesn’t currently have access to?
+
+## Does this specification enable new script execution/loading mechanisms? 
+
+## Does this specification allow an origin access to a user’s location?
+
+## Does this specification allow an origin access to sensors on a user’s device?
+
+## Does this specification allow an origin access to aspects of a user’s local computing environment?
+
+## Does this specification allow an origin access to other devices? 
+
+## Does this specification allow an origin some measure of control over a user agent’s native UI? 
+
+## Does this specification expose temporary identifiers to the web?
+
+## Does this specification distinguish between behavior in first-party and third-party contexts?
+
+## How should this specification work in the context of a user agent’s "incognito" mode?
+
+## Does this specification persist data to a user’s local device? 
+
+## Does this specification have a "Security Considerations" and "Privacy Considerations" section? 
+
+## Does this specification allow downgrading default security characteristics? 
+
+## Mitigations
+
+Mitigations for each security and privacy consideration are discussed in
+the Security and Privacy Considerations section of this document as well as the
+[WoT Security and Privacy Considerations](https://github.com/w3c/wot-security/)
+document and Security and Privacy Considerations section of each
+document describing a building block of the WoT, such as the
+[WoT Thing Description](https://github.com/w3c/wot-thing-description/),
+[WoT Binding Templates](https://github.com/w3c/wot-binding-templates/),
+and the 
+[WoT Scripting API](https://github.com/w3c/wot-scripting-api/)
+documents.
+

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -1,4 +1,5 @@
-# WoT Architecture Responses to Security and Privacy Questionnaire
+# Web of Things (WoT) Architecture
+## Responses to Security and Privacy Questionnaire
 
 This document was prepared by the Web of Things Working Group,
 responding to the questions raised in the
@@ -28,39 +29,238 @@ IoT protocols or security schemes via its built-in extension mechansisms).
 In addition, we define a general security testing procedure for WoT implementations in the
 [WoT Security Testing Plan](https://github.com/w3c/wot-security-testing-plan).
 
-## Does this specification deal with personally-identifiable information? 
+## Questions and Answers
 
-## Does this specification deal with high-value data? 
+### Does this specification deal with personally-identifiable information? 
+
+Indirectly.  The WoT Thing Description describes IoT devices and may include
+information such as location and type.  If these devices can be associated
+with an owner, then it may be possible to infer information about the
+owner.  For example, if they have a baby monitor, they may have a baby,
+are probably in a certain age range, and so forth.
+
+The WoT Thing Description (TD) also allows extensibility via the inclusion
+of custom vocabularies.  Although the WoT standard itself does not
+have any requirement for PII, it is possible an extension might.  We
+consider this aspect of PII inclusion to be out of scope.
+
+As for the indirect risk, we recommend that as a precaution a 
+WoT Thing Description should be treated _as if_ it contained PII
+and be stored, cached, and transmitted accordingly.  For example,
+we recommend that it only be distributed to authorized and authenticated
+users (for example, via a directory service or to a registered owner)
+and only be cached for a limited time.
+
+### Does this specification deal with high-value data? 
+
+Yes.  A WoT Thing may both require credentials to be accessed and
+use credentials to access other devices.  However, these are generally
+to secure M2M communication and are not user credentials.  We 
+define an architecture for managing sensitive credentials
+securely.
+
+The WoT architecture deals with the operational phase of IoT devices
+and does not specify how credentials are provisioned to devices.
+The WoT Architecture document does use a strict separation
+of private security data from public data and metadata, and
+recommends the use of an isolated private security data subsystem.
+
+The WoT Runtime and WoT Scripting API are defined in such a way
+that they do not have direct access to private credentials.
+Instead, an "abstract data type" is used in the WoT Protocol Bindings 
+to implement security operations such as authentication
+without revealing such private security data to WoT Applications.
 
 ## Does this specification introduce new state for an origin that persists across browsing sessions? 
 
+This is not a browser-oriented specification although
+WoT Things can be accessed through browsers as if they
+were web services. 
+However, no new state is introduced or required in browsers beyond
+current mechanisms (cookies, etc).
+
+WoT Things can also act as clients, however, accessing
+web services and other WoT Things acting as servers.
+It is also possible that the same device could instantiate
+multiple WoT Runtimes.  However, there is noi explicit mechanism
+for sharing state between such instances, and each instance
+can be considered a single origin.
+
 ## Does this specification expose persistent, cross-origin state to the web? 
+
+A WoT Thing may act as a server and expose interactions that 
+allow properties to be modified.  Therefore modifications by
+one client may be visible to another.
+
+This risk of this, if any, is mitigated by the fact that
+WoT Things support various mechanisms to limit access to 
+authorized users, like any other web service.
+
+When acting as a client, each WoT Thing is in effect single-origin.
+
+There is a potential fingerprinting risk, which is discussed,
+and is related to the PII risk discussed above.
+This can be mitigated by controlling access to WoT metadata
+such as WoT Thing Descriptions.
 
 ## Does this specification expose any other data to an origin that it doesn’t currently have access to?
 
+Yes.
+
+WoT Things by nature will be connected into a network of
+devices.  A single "WoT Network" application may involve
+communications between many WoT Things, some acting as
+servers, some acting as clients, some acting as both.
+
+In addition, WoT Things may act as gateways to other
+non-HTTP devices using other network protocols, such
+as MQTT or CoAP, or to interface to a variety of non-IP
+devices using BACNET, ECHONET, X10, SPI, I2C, and many
+other possibilities.
+
+Unfortunately, the single-origin model used in 
+web servers and browsers does not scale well to this model.
+
+In practice, securing an IoT Application in general is
+out of scope.  We do however discuss several common connection
+patterns (client-server, proxy, etc) and how they can be secured.
+
+This risk is mitigated by the fact that endpoint IoT devices
+are generally not exposed directly on the internet, but
+are mediated by gateways and cloud services.
+
 ## Does this specification enable new script execution/loading mechanisms? 
+
+Yes.  It enables WoT Things to run applications based
+on ECMAScript, using a constrained API, and with suitable
+restrictions, such as no direct access to private
+security data.
+
+However, a mechanism for loading new scripts is not defined
+and is currently considered to be out of scope.
+Our architecture assumes the scripts running inside a WoT Thing
+are trusted implementations provided by the manufacturer
+of the device and installed using a suitable OTA update
+mechanism; but this update mechanism is not defined in our
+architecture and is also currently considered to be out of scope.
 
 ## Does this specification allow an origin access to a user’s location?
 
+As noted above in the PII response, in theory a device
+location could be encoded in a WoT Thing Description using
+an extension vocabulary, and this could in some cases be
+associated with a user.
+Location information, however, is neither a standard nor
+a required part of the architecture.
+
+A manufacturer of a device could also define an
+interaction that returns the
+location of the device.
+We do not provide constraints on this, since it is usually
+the _purpose_ of IoT devices to provide access to sensor data.
+
+However, we do provide mechanisms to control access to
+interactions and a manufacturer can use these to
+prevent accidental disclosure to unauthorized users.
+A user can also inspect the WoT Thing Description to
+determine whether the device returns location information,
+assuming the manufacturer has not obfuscated the purpose
+of interactions.  
+
 ## Does this specification allow an origin access to sensors on a user’s device?
+
+Yes.  Many other sensors can be attached to an IoT 
+device and we do not constrain these in any way.
+
+It is the responsibility of the user to only connect and
+provision devices they trust, to select devices with
+good security, and manage the data that is
+collected appropriately.
+
+The metadata provided in the WoT Thing Description
+can be helpful in this regard since the security mechanisms
+supported by a device can be easily inspected and,
+via semantic annotations, the type of data provided
+by the device can be determined.
 
 ## Does this specification allow an origin access to aspects of a user’s local computing environment?
 
+No.  Actually, there is no executable content
+included in data or metadata provided by WoT Things.
+The only operations that a WoT Server will perform
+on behalf of a WoT Client are those that it chooses
+to support via its exposed interactions (network API).
+
 ## Does this specification allow an origin access to other devices? 
+
+Yes, as discussed above.  A WoT Thing can act as a gateway to 
+other WoT Things or to other non-IP protocols.
+
+The situation is unavoidably more complex than the client-server
+architecture of broswers.  A better analogy than browsers
+would be the microservice architecture used by many web services.
+The WoT Architecture supports best practices there, such
+as Zero-Trust networks.
 
 ## Does this specification allow an origin some measure of control over a user agent’s native UI? 
 
+No.  The WoT Architecture is M2M and makes no mention of direct
+user interfaces.
+
+That said, some devices connected via the WoT may have
+local user interfaces which might be exposed to control
+over network interactions.  Exposure of such controls
+is at the discretion of individual device manufacturers,
+who should do an analysis of security risks as part of
+their software development process.
+
 ## Does this specification expose temporary identifiers to the web?
+
+The WoT Thing Description has a required element (not actually
+mentioned in the current document, the WoT Architecture, but
+in the WoT Thing Description) which is meant to be a unique ID
+(a URN, actually).  This is necessary to support Linked Data.
+In fact, some domains, such as medical devices in the US,
+have a legal requirement to support immutable identifiers.
+
+However, we suggest that the tracking risk this poses shold
+be mitigated, whenever possible (eg if not legally disallowed
+as discussed above) by allowing such identifiers to be modified
+at least when the devices are reprovisioned.
+
+Generally, though, the identifiers in Thing Descriptions 
+are relatively long-lived.  
 
 ## Does this specification distinguish between behavior in first-party and third-party contexts?
 
+This concept is not applicable to the WoT context.
+
 ## How should this specification work in the context of a user agent’s "incognito" mode?
+
+This concept is not applicable to the WoT context, as there is no user agent.
 
 ## Does this specification persist data to a user’s local device? 
 
+Potentially, as a WoT Thing may include interactions that
+support POST requests.  IoT devices can act like web servers that 
+can of course retain state posted to them.
+
+Note that scripts cannot be sent, only data.  So devices
+always have local control over what data they retain.  WoT Things
+are never _forced_ to retain state and return it later.
+
 ## Does this specification have a "Security Considerations" and "Privacy Considerations" section? 
 
+Yes, as explained above.
+This section in the WoT Architecture document is fairly high-level
+however and meant to be a summary of the most important considerations.
+There are also sections in each WoT buliding block
+document and a more general document.
+
 ## Does this specification allow downgrading default security characteristics? 
+
+No.  A WoT Thing Description describes what a WoT Thing does and
+requires, no more and no less. 
 
 ## Mitigations
 


### PR DESCRIPTION
Ready for review/merging

- Small updates to the TAG submission request, but then a big new document, the answers to the security and privacy questionnaire.   Some of these answers are related to the WoT Scripting and WoT Thing Description... I think it might be easier for everyone just to have one document for ALL WoT documents rather than trying to do one for each.
- I may also update some of the Security and Privacy considerations.  
     - In particular I think it might also be useful to have a "Scope" section somewhere.  In particular, I say 
       certain things are out of scope, like provisioning of keys, but the discussion of LCM in the architecture 
       doc seems to imply otherwise.   It would be safer to limit the scope of the WoT Architecture to the 
       "operational" phase and NOT make it a responsibility of the WoT Runtime.
     - Not in this PR, though...
- ~~I accidentally included a commit that expands all remaining tabs in index.html to 8 spaces.  However, that commit changes NO actual content.  I think all the tabs that were expanded were actually just in the HTML head (scripts and references) anyhow.~~ (REVERTED; should deal with separately)