### PR TITLE
Updates to Security and Privacy Questionnaire

### DIFF
--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -4,10 +4,10 @@ I am requesting a TAG review of:
 
   - Name: _Web of Things (WoT) Architecture_
   - Specification URL: https://github.com/w3c/wot-architecture/tree/TAG-review
-  - Explainer, Requirements Doc, or Example code: https://github.com/w3c/wot-architecture/blob/master/proposals/WoT%20Architecture%20Explainer.md
+  - Explainer, Requirements Doc, or Example code: https://github.com/w3c/wot-architecture/blob/TAG-review/proposals/WoT%20Architecture%20Explainer.md
   - Tests: N/A
   - Github repo: https://github.com/w3c/wot-architecture
-  - Primary contacts: @mlagally, @mmccool, @mkovatc
+  - Primary contacts: @mlagally, @mmccool, @mkovatsc
 
 Further details (optional):
 
@@ -20,7 +20,7 @@ Further details (optional):
   [Additional schedule details and constraints](https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf)
   
   
-  - [X] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/master/proposals/security_and_privacy.md); this assessment is shared with all _Web of Things_ documents.
+  - [X] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/TAG-review/proposals/security_and_privacy.md); this assessment is shared with all _Web of Things_ documents.
   - [X] I have reviewed the TAG's [API Design Principles](https://w3ctag.github.io/design-principles/)
 
 You should also know that...

--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -34,6 +34,6 @@ You should also know that...
 
 We'd prefer the TAG provide feedback as (please select one):
 
-  - [ ] open issues in our Github repo for each point of feedback
-  - [X] open a single issue in our Github repo for the entire review
+  - [X] open issues in our Github repo for each point of feedback
+  - [ ] open a single issue in our Github repo for the entire review
   - [ ] leave review feedback as a comment in this issue and @-notify [github usernames]

--- a/proposals/TAG review request.md
+++ b/proposals/TAG review request.md
@@ -3,7 +3,7 @@ Góðan dag TAG！
 I am requesting a TAG review of:
 
   - Name: _Web of Things (WoT) Architecture_
-  - Specification URL: http://w3c.github.io/wot-architecture/
+  - Specification URL: https://github.com/w3c/wot-architecture/tree/TAG-review
   - Explainer, Requirements Doc, or Example code: https://github.com/w3c/wot-architecture/blob/master/proposals/WoT%20Architecture%20Explainer.md
   - Tests: N/A
   - Github repo: https://github.com/w3c/wot-architecture

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -62,7 +62,7 @@ can even include systems whose compromise would have safety implications.
 
 ## Questions and Answers
 
-### 1. Does this specification deal with personally-identifiable information? 
+### 1. [Does this specification deal with personally-identifiable information?](https://www.w3.org/TR/security-privacy-questionnaire/#pii)
 
 Indirectly.  The WoT Thing Description describes IoT devices and may include
 information such as location and type.  If these devices can be associated
@@ -82,7 +82,7 @@ we recommend that it only be distributed to authorized and authenticated
 users (for example, via a directory service or to a registered owner)
 and only be cached for a limited time.
 
-### 2. Does this specification deal with high-value data? 
+### 2. [Does this specification deal with high-value data?](https://www.w3.org/TR/security-privacy-questionnaire/#credentials)
 
 Yes.  A WoT Thing may both require credentials to be accessed and
 use credentials to access other devices.  However, these are generally
@@ -103,7 +103,7 @@ Instead, an "abstract data type" is used in the WoT Protocol Bindings
 to implement security operations such as authentication
 without revealing such private security data to WoT Applications.
 
-### 3. Does this specification introduce new state for an origin that persists across browsing sessions? 
+### 3. [Does this specification introduce new state for an origin that persists across browsing sessions?](https://www.w3.org/TR/security-privacy-questionnaire/#persistent-origin-specific-state) 
 
 This is not a browser-oriented specification although
 WoT Things can be accessed through browsers as if they
@@ -118,7 +118,7 @@ multiple WoT Runtimes.  However, there is no explicit mechanism
 for sharing state between such instances, and each instance
 can be considered a single origin.
 
-### 4. Does this specification expose persistent, cross-origin state to the web? 
+### 4. [Does this specification expose persistent, cross-origin state to the web?](https://www.w3.org/TR/security-privacy-questionnaire/#persistent-identifiers) 
 
 A WoT Thing may act as a server and expose interactions that 
 allow properties to be modified.  Therefore modifications by
@@ -135,7 +135,7 @@ and is related to the PII risk discussed above.
 This can be mitigated by controlling access to WoT metadata
 such as WoT Thing Descriptions.
 
-### 5. Does this specification expose any other data to an origin that it doesn’t currently have access to?
+### 5. [Does this specification expose any other data to an origin that it doesn’t currently have access to?](https://www.w3.org/TR/security-privacy-questionnaire/#other-data)
 
 Yes.
 
@@ -161,7 +161,7 @@ This risk is mitigated by the fact that endpoint IoT devices
 are generally not exposed directly on the internet, but
 are mediated by gateways and cloud services.
 
-### 6. Does this specification enable new script execution/loading mechanisms? 
+### 6. [Does this specification enable new script execution/loading mechanisms?](https://www.w3.org/TR/security-privacy-questionnaire/#string-to-script)
 
 Yes.  It enables WoT Things to run applications based
 on ECMAScript, using a constrained API, and with suitable
@@ -176,7 +176,7 @@ of the device and installed using a suitable update
 mechanism; but this update mechanism is not defined in our
 architecture and is also currently considered to be out of scope.
 
-### 7. Does this specification allow an origin access to a user’s location?
+### 7. [Does this specification allow an origin access to a user’s location?](https://www.w3.org/TR/security-privacy-questionnaire/#location)
 
 As noted above in the PII response, a device
 location may be encoded in a WoT Thing Description using
@@ -210,7 +210,7 @@ determine whether the device returns location information,
 assuming the manufacturer has not obfuscated the purpose
 of interactions.  
 
-### 8. Does this specification allow an origin access to sensors on a user’s device?
+### 8. [Does this specification allow an origin access to sensors on a user’s device?](https://www.w3.org/TR/security-privacy-questionnaire/#sensors)
 
 Yes.  Many other sensors can be attached to an IoT 
 device and we do not constrain these in any way.
@@ -226,7 +226,7 @@ supported by a device can be easily inspected and,
 via semantic annotations, the type of data provided
 by the device can be determined.
 
-### 9. Does this specification allow an origin access to aspects of a user’s local computing environment?
+### 9. [Does this specification allow an origin access to aspects of a user’s local computing environment?](https://www.w3.org/TR/security-privacy-questionnaire/#local-device)
 
 No, in general, if we interpret the origin as a WoT Server, the
 user's local computing environment a WoT Client that
@@ -245,7 +245,7 @@ In fact the correct answer to this question in this case is
 that the designer of a WoT Server can ensure that there is
 no _unintended_ access to the WoT Server's local computing environment.
 
-### 10. Does this specification allow an origin access to other devices? 
+### 10. [Does this specification allow an origin access to other devices?](https://www.w3.org/TR/security-privacy-questionnaire/#remote-device) 
 
 Yes, as discussed above.  A WoT Thing can act as a gateway to 
 other WoT Things or to other non-IP protocols.
@@ -276,7 +276,7 @@ In this case, such a gateway service should be protected
 by access controls (in the Zero-Trust approach, _every_ service
 uses access controls, encryption, and authentication).
 
-### 11. Does this specification allow an origin some measure of control over a user agent’s native UI? 
+### 11. [Does this specification allow an origin some measure of control over a user agent’s native UI?](https://www.w3.org/TR/security-privacy-questionnaire/#native-ui) 
 
 No.  The WoT Architecture is M2M and makes no mention of direct
 user interfaces.
@@ -288,7 +288,7 @@ is at the discretion of individual device manufacturers,
 who should do an analysis of security risks as part of
 their software development process.
 
-### 12. Does this specification expose temporary identifiers to the web?
+### 12. [Does this specification expose temporary identifiers to the web?](https://www.w3.org/TR/security-privacy-questionnaire/#temporary-id)
 
 The WoT Thing Description has a required element (not actually
 mentioned in the current document, the WoT Architecture, but
@@ -305,15 +305,15 @@ at least when the devices are reprovisioned.
 Generally, though, the identifiers in Thing Descriptions 
 are relatively long-lived.  
 
-### 13. Does this specification distinguish between behavior in first-party and third-party contexts?
+### 13. [Does this specification distinguish between behavior in first-party and third-party contexts?](https://www.w3.org/TR/security-privacy-questionnaire/#first-third-party)
 
 This concept is not applicable to the WoT context.
 
-### 14. How should this specification work in the context of a user agent’s "incognito" mode?
+### 14. [How should this specification work in the context of a user agent’s "incognito" mode?](https://www.w3.org/TR/security-privacy-questionnaire/#incognito)
 
 This concept is not applicable to the WoT context, as there is no user agent.
 
-### 15. Does this specification persist data to a user’s local device? 
+### 15. [Does this specification persist data to a user’s local device?](https://www.w3.org/TR/security-privacy-questionnaire/#storage) 
 
 A WoT Thing may be either a client or server.  Therefore we 
 have to consider this question from both the client and server 
@@ -341,22 +341,25 @@ Note that scripts cannot be included in TDs, only data.  So devices
 always have local control over what data they retain.  WoT Things
 are never _forced_ to retain state and return it later.
 
-### 16. Does this specification have a "Security Considerations" and "Privacy Considerations" section? 
+### 16. [Does this specification have a "Security Considerations" and "Privacy Considerations" section?](https://www.w3.org/TR/security-privacy-questionnaire/#considerations)
 
 Yes, as explained above.
 This section in the WoT Architecture document is fairly high-level
 however and meant to be a summary of the most important considerations.
+This section in the WoT Thing Description document is more detailed and
+specific to the Thing Description.
 There are also sections in each WoT building block
-document and a more general document.
+document and a more general document, the WoT Security and Privacy Considerations
+document, as noted in the introduction.
 
-### 17. Does this specification allow downgrading default security characteristics? 
+### 17. [Does this specification allow downgrading default security characteristics?](https://www.w3.org/TR/security-privacy-questionnaire/#relaxed-sop) 
 
 No.  A WoT Thing Description describes what a WoT Thing does and
 requires, no more and no less.
 There is however an option in the WoT Thing Description to specify
-alternative mechanisms to access a resource.
+use of one of several different alternative security mechanisms to access a resource.
 The designer of a WoT Server needs to ensure that the least secure alternative
-is sufficiently secure.
+is sufficiently secure for the intended application.
 
 ## Mitigations
 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -29,36 +29,32 @@ IoT protocols or security schemes via its built-in extension mechanisms).
 In addition, we define a general security testing procedure for WoT implementations in the
 [WoT Security Testing Plan](https://github.com/w3c/wot-security-testing-plan).
 
-Security in the IoT is unavoidably more complex as it involves general networks of communication rather 
-than just the client-server architecture of browsers. A better analogy than browsers would be the
-microservice architecture used by many web services. The WoT Architecture supports best practices there,
-such as Zero-Trust networks.
+In the documents above we address the threats and attack surfaces of the
+WoT in detail.  In the following we have answered the questions posed by the
+W3C Security and Privacy Questionnaire as best as we could... but please take into consideration
+that most of these questions are not fully applicable to our situation.
 
-For example, the "same origin policy" is considered a cornerstone of web security.  
+Security in the IoT is unavoidably more complex than in the web as it involves
+general networks of communication rather
+than just the client-server architecture of web servers and browsers.
+For example, the "same origin policy" is considered a cornerstone of web security.
 In addition,
-security is often concerned with the "user's device" or the "user agent", which is
-always a client (the browser).
-However, the IoT is often concerned with machine-to-machine communication.
-If an IoT device is associated with a user, it is may be a client, or
-a server---or even both at the same time.  Finally, an IoT device may have
-a "user interface" but it will be more varied than that of the browser.
+security on the web is often concerned with the "user's device" or the "user agent",
+which is always a client (the browser).
+However, the IoT is often more concerned with machine-to-machine communication;
+there is no "user".
+If an IoT device _is_ associated with a user, it may be a client, or
+a server---or even both at the same time.
+Finally, even if an IoT device has
+a "user interface" it will be more varied than that of the browser,
+and under control of the device manufacturer, not the proposed WoT standard.
 
-On the web, the "origin" means content from a specific web server, and 
-we usually worry about protecting the user and the client, which is a browser.
-In the WoT context, "origin" could be interpreted as a WoT Server (WoT Thing in server role)
-and "browser" would be a WoT Client.
-
-The kinds of risks we have to deal with in the WoT are different than 
+The kinds of risks we have to deal with in the WoT are also different than
 those in the Web.  For example, the WoT does not support downloading
 and executing arbitrary scripts from other devices.  So many risks having
 to deal with such execution are not relevant.  On the other hand, the types
 of sensors and actuators supported by IoT devices are much broader and
 can even include systems whose compromise would have safety implications.
-
-In the documents above we address the threats and attack surfaces of the 
-WoT in detail.  In the following we have answered the questions posed by the
-Web Security group as best as we could... but please take into consideration
-that most of these questions are not fully applicable to our situation.
 
 ## Questions and Answers
 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -29,6 +29,37 @@ IoT protocols or security schemes via its built-in extension mechanisms).
 In addition, we define a general security testing procedure for WoT implementations in the
 [WoT Security Testing Plan](https://github.com/w3c/wot-security-testing-plan).
 
+Security in the IoT is unavoidably more complex as it involves general networks of communication rather 
+than just the client-server architecture of browsers. A better analogy than browsers would be the
+microservice architecture used by many web services. The WoT Architecture supports best practices there,
+such as Zero-Trust networks.
+
+For example, the "same origin policy" is considered a cornerstone of web security.  
+In addition,
+security is often concerned with the "user's device" or the "user agent", which is
+always a client (the browser).
+However, the IoT is often concerned with machine-to-machine communication.
+If an IoT device is associated with a user, it is may be a client, or
+a server---or even both at the same time.  Finally, an IoT device may have
+a "user interface" but it will be more varied than that of the browser.
+
+On the web, the "origin" means content from a specific web server, and 
+we usually worry about protecting the user and the client, which is a browser.
+In the WoT context, "origin" could be interpreted as a WoT Server (WoT Thing in server role)
+and "browser" would be a WoT Client.
+
+The kinds of risks we have to deal with in the WoT are different than 
+those in the Web.  For example, the WoT does not support downloading
+and executing arbitrary scripts from other devices.  So many risks having
+to deal with such execution are not relevant.  On the other hand, the types
+of sensors and actuators supported by IoT devices are much broader and
+can even include systems whose compromise would have safety implications.
+
+In the documents above we address the threats and attack surfaces of the 
+WoT in detail.  In the following we have answered the questions posed by the
+Web Security group as best as we could... but please take into consideration
+that most of these questions are not fully applicable to our situation.
+
 ## Questions and Answers
 
 ### Does this specification deal with personally-identifiable information? 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -1,5 +1,5 @@
 # W3C Web of Things
-# Responses to the W3C Security and Privacy Questionnaire
+## Responses to the W3C Security and Privacy Questionnaire
 
 This document was prepared by the Web of Things Working Group,
 responding to the questions raised in the
@@ -62,7 +62,7 @@ can even include systems whose compromise would have safety implications.
 
 ## Questions and Answers
 
-### Does this specification deal with personally-identifiable information? 
+### 1. Does this specification deal with personally-identifiable information? 
 
 Indirectly.  The WoT Thing Description describes IoT devices and may include
 information such as location and type.  If these devices can be associated
@@ -82,7 +82,7 @@ we recommend that it only be distributed to authorized and authenticated
 users (for example, via a directory service or to a registered owner)
 and only be cached for a limited time.
 
-### Does this specification deal with high-value data? 
+### 2. Does this specification deal with high-value data? 
 
 Yes.  A WoT Thing may both require credentials to be accessed and
 use credentials to access other devices.  However, these are generally
@@ -103,7 +103,7 @@ Instead, an "abstract data type" is used in the WoT Protocol Bindings
 to implement security operations such as authentication
 without revealing such private security data to WoT Applications.
 
-### Does this specification introduce new state for an origin that persists across browsing sessions? 
+### 3. Does this specification introduce new state for an origin that persists across browsing sessions? 
 
 This is not a browser-oriented specification although
 WoT Things can be accessed through browsers as if they
@@ -118,7 +118,7 @@ multiple WoT Runtimes.  However, there is no explicit mechanism
 for sharing state between such instances, and each instance
 can be considered a single origin.
 
-### Does this specification expose persistent, cross-origin state to the web? 
+### 4. Does this specification expose persistent, cross-origin state to the web? 
 
 A WoT Thing may act as a server and expose interactions that 
 allow properties to be modified.  Therefore modifications by
@@ -135,7 +135,7 @@ and is related to the PII risk discussed above.
 This can be mitigated by controlling access to WoT metadata
 such as WoT Thing Descriptions.
 
-### Does this specification expose any other data to an origin that it doesn’t currently have access to?
+### 5. Does this specification expose any other data to an origin that it doesn’t currently have access to?
 
 Yes.
 
@@ -161,7 +161,7 @@ This risk is mitigated by the fact that endpoint IoT devices
 are generally not exposed directly on the internet, but
 are mediated by gateways and cloud services.
 
-### Does this specification enable new script execution/loading mechanisms? 
+### 6. Does this specification enable new script execution/loading mechanisms? 
 
 Yes.  It enables WoT Things to run applications based
 on ECMAScript, using a constrained API, and with suitable
@@ -176,7 +176,7 @@ of the device and installed using a suitable update
 mechanism; but this update mechanism is not defined in our
 architecture and is also currently considered to be out of scope.
 
-### Does this specification allow an origin access to a user’s location?
+### 7. Does this specification allow an origin access to a user’s location?
 
 As noted above in the PII response, a device
 location may be encoded in a WoT Thing Description using
@@ -210,7 +210,7 @@ determine whether the device returns location information,
 assuming the manufacturer has not obfuscated the purpose
 of interactions.  
 
-### Does this specification allow an origin access to sensors on a user’s device?
+### 8. Does this specification allow an origin access to sensors on a user’s device?
 
 Yes.  Many other sensors can be attached to an IoT 
 device and we do not constrain these in any way.
@@ -226,7 +226,7 @@ supported by a device can be easily inspected and,
 via semantic annotations, the type of data provided
 by the device can be determined.
 
-### Does this specification allow an origin access to aspects of a user’s local computing environment?
+### 9. Does this specification allow an origin access to aspects of a user’s local computing environment?
 
 No, in general, if we interpret the origin as a WoT Server, the
 user's local computing environment a WoT Client that
@@ -245,7 +245,7 @@ In fact the correct answer to this question in this case is
 that the designer of a WoT Server can ensure that there is
 no _unintended_ access to the WoT Server's local computing environment.
 
-### Does this specification allow an origin access to other devices? 
+### 10. Does this specification allow an origin access to other devices? 
 
 Yes, as discussed above.  A WoT Thing can act as a gateway to 
 other WoT Things or to other non-IP protocols.
@@ -276,7 +276,7 @@ In this case, such a gateway service should be protected
 by access controls (in the Zero-Trust approach, _every_ service
 uses access controls, encryption, and authentication).
 
-### Does this specification allow an origin some measure of control over a user agent’s native UI? 
+### 11. Does this specification allow an origin some measure of control over a user agent’s native UI? 
 
 No.  The WoT Architecture is M2M and makes no mention of direct
 user interfaces.
@@ -288,7 +288,7 @@ is at the discretion of individual device manufacturers,
 who should do an analysis of security risks as part of
 their software development process.
 
-### Does this specification expose temporary identifiers to the web?
+### 12. Does this specification expose temporary identifiers to the web?
 
 The WoT Thing Description has a required element (not actually
 mentioned in the current document, the WoT Architecture, but
@@ -305,15 +305,15 @@ at least when the devices are reprovisioned.
 Generally, though, the identifiers in Thing Descriptions 
 are relatively long-lived.  
 
-### Does this specification distinguish between behavior in first-party and third-party contexts?
+### 13. Does this specification distinguish between behavior in first-party and third-party contexts?
 
 This concept is not applicable to the WoT context.
 
-### How should this specification work in the context of a user agent’s "incognito" mode?
+### 14. How should this specification work in the context of a user agent’s "incognito" mode?
 
 This concept is not applicable to the WoT context, as there is no user agent.
 
-### Does this specification persist data to a user’s local device? 
+### 15. Does this specification persist data to a user’s local device? 
 
 A WoT Thing may be either a client or server.  Therefore we 
 have to consider this question from both the client and server 
@@ -341,7 +341,7 @@ Note that scripts cannot be included in TDs, only data.  So devices
 always have local control over what data they retain.  WoT Things
 are never _forced_ to retain state and return it later.
 
-### Does this specification have a "Security Considerations" and "Privacy Considerations" section? 
+### 16. Does this specification have a "Security Considerations" and "Privacy Considerations" section? 
 
 Yes, as explained above.
 This section in the WoT Architecture document is fairly high-level
@@ -349,7 +349,7 @@ however and meant to be a summary of the most important considerations.
 There are also sections in each WoT building block
 document and a more general document.
 
-### Does this specification allow downgrading default security characteristics? 
+### 17. Does this specification allow downgrading default security characteristics? 
 
 No.  A WoT Thing Description describes what a WoT Thing does and
 requires, no more and no less.

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -1,19 +1,23 @@
-# Web of Things (WoT) Architecture
-## Responses to Security and Privacy Questionnaire
+# W3C Web of Things
+# Responses to the W3C Security and Privacy Questionnaire
 
 This document was prepared by the Web of Things Working Group,
 responding to the questions raised in the
 [Self-Review Questionnaire: Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/) 
-published by the W3C TAG 
-related to the 
-[WoT Architecture](https://github.com/w3c/wot-architecture) document.
+document published by the W3C TAG. 
+These responses are related to both the 
+[WoT Architecture](https://github.com/w3c/wot-architecture) document
+and the
+[WoT Thing Description](https://github.com/w3c/wot-architecture) document.
 
-Please raise issues on the
-[WoT Architecture GitHub Issue page](https://github.com/w3c/wot-architecture/issues).
+Please raise issues specific to the WoT Architecture document on the
+[WoT Architecture GitHub Issue page](https://github.com/w3c/wot-architecture/issues)
+and to the WoT Thing Description document on the
+[WoT Thing Description GitHub Issue page](https://github.com/w3c/wot-thing-description/issues).
 
 ## Background
 
-The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security)
+The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security) document
 includes an extensive threat model,
 and considers both passive and active attacks to
 both data (payload transactions) and metadata (Thing Descriptions).

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -63,7 +63,8 @@ The WoT architecture deals with the operational phase of IoT devices
 and does not specify how credentials are provisioned to devices.
 The WoT Architecture document does use a strict separation
 of private security data from public data and metadata, and
-recommends the use of an isolated private security data subsystem.
+recommends the use of an isolated private security data subsystem,
+such as TPM (Trusted Platform Module).
 
 The WoT Runtime and WoT Scripting API are defined in such a way
 that they do not have direct access to private credentials.

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -224,11 +224,22 @@ by the device can be determined.
 
 ### Does this specification allow an origin access to aspects of a user’s local computing environment?
 
-No.  Actually, there is no executable content
-included in data or metadata provided by WoT Things.
+No, in general, if we interpret the origin as a WoT Server, the
+user's local computing environment a WoT Client that
+retreives content from that WoT Server.
+There is no executable content
+expected in data or required in the metadata (Thing Description) provided by WoT Things.
+
+If we reverse the definitions, and let the origin be a WoT Client
+and the user be a WoT Server, which is possible in some WoT topologies,
+in general the answer is still no under reasonable constraints on system design,
+such as not exposing a capability to execute scripts on the WoT Server.
 The only operations that a WoT Server will perform
 on behalf of a WoT Client are those that it chooses
 to support via its exposed interactions (network API).
+In fact the correct answer to this question in this case is
+that the designer of a WoT Server can ensure that there is
+no _unintended_ access to the WoT Server's local computing environment.
 
 ### Does this specification allow an origin access to other devices? 
 

--- a/proposals/security_and_privacy.md
+++ b/proposals/security_and_privacy.md
@@ -348,7 +348,11 @@ document and a more general document.
 ### Does this specification allow downgrading default security characteristics? 
 
 No.  A WoT Thing Description describes what a WoT Thing does and
-requires, no more and no less. 
+requires, no more and no less.
+There is however an option in the WoT Thing Description to specify
+alternative mechanisms to access a resource.
+The designer of a WoT Server needs to ensure that the least secure alternative
+is sufficiently secure.
 
 ## Mitigations
 


### PR DESCRIPTION
At our Security TF call on Monday, March 25 we made some edits to our responses to the Security and Privacy Questionnaire, but did not update the version submitted for TAG review. I've created this PR to review the changes.

This replaces https://github.com/w3c/wot-architecture/pull/184 (basically, I branched master into TAG-review-updates so that other unrelated updates to the master would not affect this update).   **I will delete this branch once this PR is merged; the purpose of the TAG-review-updates branch is just to stage updates like this, not to serve as another review target.**