### PR TITLE
Move Section 6.2 to the end of 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -1558,6 +1558,9 @@ a[href].internalDFN {
                 layer) information. More information about the TD can be
                 found in <a href="#sec-thing-description"></a>.
             </p>
+            <p class="ednote" title="TODO">
+                There is text incoming to explain the basics around Things, Consumers, and Intermediaries.
+            </p>
             <p>
                 <a href="#architecture-abstract"></a> shows an overview
                 of how these WoT concepts can be mapped to various
@@ -1569,96 +1572,6 @@ a[href].internalDFN {
                 <figcaption>Abstract Architecture of W3C
                     WoT</figcaption>
             </figure>
-        </section>
-        <section id="sec-WoT-servient-architecture-high-level">
-            <h2>System Configurations</h2>
-
-            <p>This section illustrates the behavior of WoT
-                components using system configuration diagrams.</p>
-
-            <section>
-                <h3>Direct Communication</h3>
-                <p>
-                    <a href="#high-level-application-device"></a> shows
-                    direct communication between a <a>WoT Server</a>, that is
-                    exposing a thing and a <a>WoT Client</a> that is using it.
-                    Direct communication applies when both components
-                    use the same network protocol(s) and are accessible
-                    to each other.
-                </p>
-                <figure id="high-level-application-device">
-                    <img
-                        src="images/arch-high-level-application-device-alt2.png" />
-                    <figcaption>High level architecture of
-                        application and device</figcaption>
-                </figure>
-
-                Conceptually, a <a>WoT Server</a> can be thought to have an <a>Exposed Thing</a>
-                that provides an interface that conforms to the TD. A
-                <a>WoT Client</a> can be considered to contain a <a>Consumed Thing</a>
-                for each of the <a>WoT Servers</a> it connects to
-                that provides a programming interface that can be used
-                by applications. A <a>WoT Client</a> can generate a
-                <a>Consumed Thing</a> instance by interpreting a TD.
-                Communication between the <a>WoT Client</a> and the <a>WoT Server</a>
-                is performed by exchanging messages over a direct
-                network connection between a <a>Consumed Thing</a> and an
-                <a>Exposed Thing</a>.
-
-            </section>
-            <section>
-                <h3>Indirect Communication</h3>
-
-                <p>
-                    In <a
-                        href="#high-level-application-proxy-device-new"></a>
-                    a <a>WoT Client</a> and a <a>WoT Server</a> connect to each other
-                    via a proxy. A proxy is required as an intermediary
-                    if the components use different protocols (gateway)
-                    or if they are on different networks that require
-                    authentication and provide access control (e.g.
-                    firewalls).
-                </p>
-
-                <figure id="high-level-application-proxy-device-new">
-                    <img
-                        src="images/arch-high-level-application-proxy-device-alt2.png" />
-                    <figcaption>High level architecture
-                        with proxy</figcaption>
-                </figure>
-
-                <p>
-                    A proxy combines <a>Exposed Thing</a> and <a>Consumed Thing</a>
-                    functionality, and relays messages that are exchanged
-                    between a <a>WoT Client</a> and a <a>WoT Server</a>. In a proxy,
-                    a <a>Consumed Thing</a> creates a <em>shadow thing
-                        instance</em> of the <a>Exposed Thing</a> of a <a>WoT Server</a>, and
-                    a <a>WoT Client</a> can access the shadow instance through
-                    the <a>Exposed Thing</a> of the proxy.
-                </p>
-                <p>The <a>Exposed Thing</a> and <a>Consumed Thing</a> of a proxy can
-                    communicate with the <a>WoT Client</a> and the <a>WoT Server</a>
-                    in different protocols. For example, a proxy can
-                    provide a bridge between a device that uses CoAP and
-                    an application that uses HTTP. Even when there are
-                    multiple devices and they use different protocols,
-                    an application can communicate with those devices
-                    using a single protocol through the proxy. The same
-                    is true for device authentication. A client only
-                    needs to handle a single authentication method even
-                    when multiple devices connected to a proxy use
-                    different authentication methods.</p>
-                <p>A proxy creates a <a>Consumed Thing</a> based on a TD and
-                    generates another TD for a shadow thing instance.
-                    The TD for a shadow device uses a new identifier
-                    different from the original device TD’s, and
-                    contains interfaces for other communication
-                    protocols if necessary. A proxy then creates an
-                    <a>Exposed Thing</a> that implements the bridge to the
-                    originating thing. A client communicates with a
-                    device via a proxy through a <a>Consumed Thing</a> that
-                    conforms to the TD for the shadow thing instance.</p>
-            </section>
         </section>
         <section id="sec-web-thing">
             <h2>Web Thing</h2>
@@ -2124,6 +2037,96 @@ a[href].internalDFN {
                     declare a data schema to provide more detailed
                     semantic metadata for the data exchanged.</span>
             </p>
+        </section>
+        <section id="sec-WoT-servient-architecture-high-level">
+            <h2>System Configurations</h2>
+
+            <p>This section illustrates the behavior of WoT
+                components using system configuration diagrams.</p>
+
+            <section>
+                <h3>Direct Communication</h3>
+                <p>
+                    <a href="#high-level-application-device"></a> shows
+                    direct communication between a <a>WoT Server</a>, that is
+                    exposing a thing and a <a>WoT Client</a> that is using it.
+                    Direct communication applies when both components
+                    use the same network protocol(s) and are accessible
+                    to each other.
+                </p>
+                <figure id="high-level-application-device">
+                    <img
+                        src="images/arch-high-level-application-device-alt2.png" />
+                    <figcaption>High level architecture of
+                        application and device</figcaption>
+                </figure>
+
+                Conceptually, a <a>WoT Server</a> can be thought to have an <a>Exposed Thing</a>
+                that provides an interface that conforms to the TD. A
+                <a>WoT Client</a> can be considered to contain a <a>Consumed Thing</a>
+                for each of the <a>WoT Servers</a> it connects to
+                that provides a programming interface that can be used
+                by applications. A <a>WoT Client</a> can generate a
+                <a>Consumed Thing</a> instance by interpreting a TD.
+                Communication between the <a>WoT Client</a> and the <a>WoT Server</a>
+                is performed by exchanging messages over a direct
+                network connection between a <a>Consumed Thing</a> and an
+                <a>Exposed Thing</a>.
+
+            </section>
+            <section>
+                <h3>Indirect Communication</h3>
+
+                <p>
+                    In <a
+                        href="#high-level-application-proxy-device-new"></a>
+                    a <a>WoT Client</a> and a <a>WoT Server</a> connect to each other
+                    via a proxy. A proxy is required as an intermediary
+                    if the components use different protocols (gateway)
+                    or if they are on different networks that require
+                    authentication and provide access control (e.g.
+                    firewalls).
+                </p>
+
+                <figure id="high-level-application-proxy-device-new">
+                    <img
+                        src="images/arch-high-level-application-proxy-device-alt2.png" />
+                    <figcaption>High level architecture
+                        with proxy</figcaption>
+                </figure>
+
+                <p>
+                    A proxy combines <a>Exposed Thing</a> and <a>Consumed Thing</a>
+                    functionality, and relays messages that are exchanged
+                    between a <a>WoT Client</a> and a <a>WoT Server</a>. In a proxy,
+                    a <a>Consumed Thing</a> creates a <em>shadow thing
+                        instance</em> of the <a>Exposed Thing</a> of a <a>WoT Server</a>, and
+                    a <a>WoT Client</a> can access the shadow instance through
+                    the <a>Exposed Thing</a> of the proxy.
+                </p>
+                <p>The <a>Exposed Thing</a> and <a>Consumed Thing</a> of a proxy can
+                    communicate with the <a>WoT Client</a> and the <a>WoT Server</a>
+                    in different protocols. For example, a proxy can
+                    provide a bridge between a device that uses CoAP and
+                    an application that uses HTTP. Even when there are
+                    multiple devices and they use different protocols,
+                    an application can communicate with those devices
+                    using a single protocol through the proxy. The same
+                    is true for device authentication. A client only
+                    needs to handle a single authentication method even
+                    when multiple devices connected to a proxy use
+                    different authentication methods.</p>
+                <p>A proxy creates a <a>Consumed Thing</a> based on a TD and
+                    generates another TD for a shadow thing instance.
+                    The TD for a shadow device uses a new identifier
+                    different from the original device TD’s, and
+                    contains interfaces for other communication
+                    protocols if necessary. A proxy then creates an
+                    <a>Exposed Thing</a> that implements the bridge to the
+                    originating thing. A client communicates with a
+                    device via a proxy through a <a>Consumed Thing</a> that
+                    conforms to the TD for the shadow thing instance.</p>
+            </section>
         </section>
     </section>
 


### PR DESCRIPTION
First step to fix #188 

Looking closer it turned out that we do not need a new Section 6.2, but the high-level view of Things, Consumers, and Intermediaries can be part of 6.1 Overview.

The "system configurations" are now 6.10.