### PR TITLE
Revision of Section 6 to reflect Things and Consumers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1115,7 +1115,7 @@ a[href].internalDFN {
                 </figure>
             </section>
         </section>
-        <section>
+        <section id="sec-use-case-summary">
             <h2>Summary</h2>
             <p>
                 The previous section described various architecture
@@ -1527,47 +1527,53 @@ a[href].internalDFN {
             </p>
             <p>
                 A Thing can also abstract a virtual entity, which is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
-                
-                In this case, all metadata is consolidated in a single <a>Thing Description</a>.
-                In cases of complex systems, a Thing can also link to other Things and express the relation type. 
-
-                Central feature of the Web - linking.
+                One option for the composition is to provide a single, consolidated <a>Thing Description</a> that contains the superset of capabilities for the virtual entity.
+                In cases where the composition is rather complex, its <a>Thing Description</a> may <emph>link</emph> to hierarchical sub-Things within the composition.
+                The main <a>Thing Description</a> acts as entry point and only contain general metadata and potentially overarching capabilities.
+                This allows grouping of certain aspects of more complex Things.
             </p>
             <p>
-                Things can be linked to and from each other (e.g., to represent a complex system composed of several hierarchical Things)
-                or can link to additional resources (e.g., manuals or catalog entries), thereby making the Web of Things browsable.
-                
-
+                Linking does not only apply to hierarchical Things, but relations between Things and other resources in general.
+                Link relation types express how Things relate, for instance, a switch controlling a light or a room monitored by a motion sensor.
+                Other resources related to a Thing can be manuals, catalogs for spare parts, CAD files, a graphical UI, or any other document on the Web.
+                Overall, Web linking among Things makes the Web of Things browsable.
+                This can be further facilitated by providing Thing directories that manage an index of available Things, usually by caching their TD representation.
+                In summary, <a>Thing Descriptions</a> MAY link to other <a>Things</a> and other resources on the Web to form a Web of Things.
+                Links in <a>Thing Descriptions</a> MUST have a relation type.
             </p>
             <p class="ednote" title="TODO">
                 Figure to illustrate linked Things.
             </p>
-
-
-
             <p>
-                A simple example is a Thing being the digital
-                    representation of a physical IoT devices, which also
-                    directly provides the interface for interaction. A Thing
-                    may also be hosted on a gateway or the cloud,
-                    representing a physical entity with which clients cannot
-                    communicate directly (e.g., a legacy device) or not all
-                    (e.g., a room or table). Virtual entities like a room
-                    are often represented by a composition of one or more
-                    sensors and actuators, each of which may also be
-                    available as an individual Thing.
+                Things must be hosted on networked system components with a software stack to realize interaction through a network-facing interface, the <a>WoT Interface</a> of a <a>Thing</a>.
+                One example of this is an HTTP server running on an embedded device with sensors and actutors interfacing the physical entity behind the Thing abstraction.
+                However, W3C WoT does not mandate where <a>Things</a> are hosted; it can be on the IoT device directly, an <a>Edge device</a> such as a gateway box, or the cloud.
+            </p>
+            <p>
+                A typical deployment challenge is that local networks are not reachable from the Internet, usually because of IPv4 NATs or firewalls.
+                To remedy this situation, W3C WoT allows for <a>Intermediaries</a> between <a>Things</a> and <a>Consumers</a>.
+                <a>Intermediaries</a> can act as proxies for <a>Things</a>, where the <a>Intermediary</a> has a <a>Thing Description</a> similar to the original <a>Thing</a>,
+                but which points to the <a>WoT Interface</a> provided by the <a>Intermediary</a>.
+                <a>Intermediaries</a> may also augment existing <a>Things</a> with additional capabilities or compose a new <a>Thing</a> out of multiple available <a>Things</a>,
+                thereby forming a virtual entity.
+                To <a>Consumers</a>, <a>Intermediaries</a> look like <a>Things</a>, as they possess <a>Thing Descriptions</a> and provide a <a>WoT Interface</a>,
+                and hence might be indistinguishable from <a>Things</a> in a layered system architecture like the Web [[?REST]].
+                An identifier in the <a>Thing Description</a> MUST allow for the correlation of multiple <a>Thing Descriptions</a> representing the same original <a>Thing</a> or ultimately unique physical entity.
             </p>
             <p class="ednote" title="TODO">
                 Figure to illustrate intermediaries.
             </p>
             <p>
+                Another remedy for unreachable local networks would be to bind the <a>WoT Interface</a> to a protocol that establishes the connection from the <a>Thing</a> within the local network to a publicly reachable <a>Consumer</a>.
+            </p>
+            <p>
                 Things MAY be bundled together with a Consumer to enable Thing-to-Thing interaction.
+                Usually, the Consumer behavior is embedded in the software also implementing the behavior of the Thing.
                 The configuration of the Consumer behavior MAY be exposed through the Thing.
-                or MAY be defined out of band, for instance, within
-
-                <a href="#architecture-abstract"></a> shows an overview
-                of how these WoT concepts can be mapped to various
-                components and devices in a connected system.
+            </p>
+            <p>
+                <a href="#architecture-abstract"></a> summarizes how the WoT concepts introduced above can be applied and combined to address the use cases summarized in <a href="#sec-use-case-summary"></a>.
+                In particular, W3C WoT is applicable to all levels relevant for IoT applications: the device level, edge level, and cloud level.
             </p>
             <figure id="architecture-abstract">
                 <img src="images/architecture-abstract-new.png"

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                 publisher : "W3C",
                 date : "October 2017"
             },
-            "HMI" : {
+            "HCI" : {
                 title : "The Encyclopedia of Human-Computer Interaction, 2nd Ed",
                 author : "Mads Soegaard, Rikke Friis Dam",
                 publisher : "Interaction Design Foundation",
@@ -375,6 +375,11 @@ a[href].internalDFN {
                 created by a native WoT Runtime, or instantiated
                 as an object by a Scripting API implementation.</dd>
             <dt>
+                <dfn>Consumer</dfn>
+            </dt>
+            <dd>An entity that can process the WoT Thing Description format
+                and interact with Things (i.e., consume Things).</dd>
+            <dt>
                 <dfn>Digital Twin</dfn>
             </dt>
             <dd>A digital twin is a virtual representation of a
@@ -400,7 +405,7 @@ a[href].internalDFN {
                 <dfn>Event</dfn>
             </dt>
             <dd>An Interaction Affordance that describes an event source,
-                which asynchronously pushes event data to clients
+                which asynchronously pushes event data to Consumers
                 (e.g., overheating alerts).</dd>
             <dt>
                 <dfn>Execution Environment</dfn>
@@ -419,7 +424,7 @@ a[href].internalDFN {
             </dt>
             <dd>A software abstraction that represents a Thing 
                 implemented locally that be accessed over the network by remote
-                WoT Clients. 
+                Consumers. 
                 The abstraction might be
                 created by a native WoT Runtime, or instantiated
                 as an object by a Scripting API implementation.</dd>
@@ -429,13 +434,13 @@ a[href].internalDFN {
             <dd>A serialization of a Protocol Binding in hypermedia, that is,
                 either a Web link [[!RFC8288]] for navigation or a Web form for
                 performing other operations. Forms can be seen as request templates
-                provided by the server to be completeted and sent by the client.</dd>
+                provided by the Thing to be completeted and sent by the Consumer.</dd>
             <dt>
                 <dfn>Interaction Affordance</dfn>
             </dt>
             <dd>
-                Metadata of a Thing that shows the possible choices to clients,
-                thereby suggesting how clients may interact with the Thing.
+                Metadata of a Thing that shows and describes the possible choices to Consumers,
+                thereby suggesting how Consumers may interact with the Thing.
                 There are many types of potential affordances, but 
                 W3C WoT defines three types of Interaction Affordances:
                 Properties, Actions, and Events.</dd>
@@ -463,7 +468,7 @@ a[href].internalDFN {
                 <dfn data-lt="WoT Protocol Binding">Protocol Binding</dfn>
             </dt>
             <dd>The mapping from an Interaction Affordance to concrete messages of a specific protocol,
-                thereby informing clients how to activate the Interaction Affordance.
+                thereby informing Consumers how to activate the Interaction Affordance.
                 W3C WoT serializes Protocol Bindings as hypermedia controls.</dd>
             <dt>
                 <dfn>Scripting Runtime</dfn>
@@ -475,10 +480,9 @@ a[href].internalDFN {
                 <dfn>Servient</dfn>
             </dt>
             <dd>A software stack that implements the WoT building
-                blocks. A Servient can host and expose Things (server
-                role) and/or consume Things (client role). Servients
-                often support multiple Protocol Bindings to enable
-                interaction with different platforms.</dd>
+                blocks. A Servient can host and expose Things and/or host Consumers that consume Things.
+                Servients can support multiple Protocol Bindings to enable
+                interaction with different IoT platforms.</dd>
             <dt>
                 <dfn>Subprotocol</dfn>
             </dt>
@@ -496,7 +500,7 @@ a[href].internalDFN {
                 including communication metadata of WoT Binding
                 Templates.</dd>
             <dt>
-                <dfn>Thing</dfn>
+                <dfn>Thing</dfn> or <dfn>Web Thing</dfn>
             </dt>
             <dd>An abstraction of a physical or a virtual entity
                 whose metadata and interfaces are described by a WoT
@@ -530,21 +534,10 @@ a[href].internalDFN {
             <dd>An instance of a Thing that represents a Thing that is located 
                 on another system component.</dd>
             <dt>
-                <dfn>WoT Client</dfn>
-            </dt>
-            <dd>An entity that can connect with a network interface
-                described by a WoT Thing Description (i.e., consume a
-                Thing). WoT Clients usually implement multiple Protocol
-                Bindings. WoT Client is also used to refer to a Servient
-                in client role only.</dd>
-            <dt>
                 <dfn>WoT Interface</dfn>
             </dt>
-            <dd>The WoT Interface is the network-facing interface
-                that is described by a TD. This requires the mapping
-                rules of Protocol Bindings between the abstract WoT
-                Runtime (Thing level) to a network-facing interface
-                (protocol level).</dd>
+            <dd>The network-facing interface of a Thing
+                that is described by a Thing Description.</dd>
             <dt>
                 <dfn>WoT Runtime</dfn>
             </dt>
@@ -1515,53 +1508,63 @@ a[href].internalDFN {
 
         <section id="sec-architecture-overview">
             <h2>Overview</h2>
-            <p>A WoT system conceptually consists of things that
-                communicate with each other over network connections.
-                These things can take different logical roles in the
-                communication:</p>
-            <ul>
-                <li><a>WoT Client</a>: A thing can behave as a
-                    client, which is an active component and issues
-                    requests to other things. Requests use the
-                    functionalities that are provided by the other
-                    things, we call this interaction <em>to consume
-                        a thing</em>.</li>
-                <li><a>WoT Server</a>: A thing can behave as a
-                    server, which is a component that reacts to requests
-                    from other things. Requests query or modify the
-                    state of a thing, we call this interaction <em>to
-                        expose a thing</em>. Note that the server, is not
-                    purely a passive reactive component, since it can
-                    offer a subscribe/notify mechanism, which allows
-                    clients to be notified about state changes of a
-                    thing.</li>
-                <li><a>WoT Servient</a>: A thing can behave both
-                    as a client and a server, i.e. it can <em>expose</em>
-                    functionality to other things and it can <em>consume</em>
-                    functionalities that are provided by other things.</li>
-            </ul>
-
-            <p>Note that these concepts are logical definitions
-                based on the tasks of a thing. They do not require that
-                an exposed thing must be implemented with a (Web) server
-                and a consumed thing as a (Web) client.</p>
             <p>
-                A <a>WoT Thing Description</a> (TD) contains information
-                about the structure, capabilities, functions and
-                interfaces of an exposed thing. Each Web of Things
-                device MUST have a corresponding TD. The thing
-                description is used by the consumer of a thing to
-                interact with it by obtaining and interpreting a TD of
-                the device. A TD contains, among other things, a
-                device’s identifier, functions and attributes of a
-                device and communication protocols (i.e. transport
-                layer) information. More information about the TD can be
-                found in <a href="#sec-thing-description"></a>.
+                To address the use cases in Section 4 and fulfill the requirements in Section 5,
+                the Web of Things builds on top of the concept of Web Things -- usually simply called <a>Things</a> -- that can be used by so-called <a>Consumers</a>.
+                A Thing is the abstraction of a physical or virtual entity (e.g., a device or a room, resp.)
+                and is described by standardized metadata.
+                In W3C WoT, the description metadata MUST be a WoT Thing Description [[!wot-thing-description]].
+                A Thing Description (TD) is instance-specific (i.e., describes an individual Thing, not types of Things)
+                and is the default Web representation of a Thing.
+                There MAY be other Web representations of a Thing such as an HTML-based user interface or simply an image of the physical entity.
+                However, the WoT Thing Description is a standardized, machine-understandable representation format
+                that allows <a>Consumers</a> to discover and interpret the capabilities of a Thing (through semantic annotations)
+                and to adapt to different implementations (e.g., different protocols or data structures) when interacting with a Thing,
+                thereby enabling interoperability across different <a>IoT platforms</a>, i.e., different ecosystems and standards.
             </p>
             <p class="ednote" title="TODO">
-                There is text incoming to explain the basics around Things, Consumers, and Intermediaries.
+                Simple figure to illustrate Consumer--Thing interaction.
             </p>
             <p>
+                A Thing can also abstract a virtual entity, which is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
+                
+                In this case, all metadata is consolidated in a single <a>Thing Description</a>.
+                In cases of complex systems, a Thing can also link to other Things and express the relation type. 
+
+                Central feature of the Web - linking.
+            </p>
+            <p>
+                Things can be linked to and from each other (e.g., to represent a complex system composed of several hierarchical Things)
+                or can link to additional resources (e.g., manuals or catalog entries), thereby making the Web of Things browsable.
+                
+
+            </p>
+            <p class="ednote" title="TODO">
+                Figure to illustrate linked Things.
+            </p>
+
+
+
+            <p>
+                A simple example is a Thing being the digital
+                    representation of a physical IoT devices, which also
+                    directly provides the interface for interaction. A Thing
+                    may also be hosted on a gateway or the cloud,
+                    representing a physical entity with which clients cannot
+                    communicate directly (e.g., a legacy device) or not all
+                    (e.g., a room or table). Virtual entities like a room
+                    are often represented by a composition of one or more
+                    sensors and actuators, each of which may also be
+                    available as an individual Thing.
+            </p>
+            <p class="ednote" title="TODO">
+                Figure to illustrate intermediaries.
+            </p>
+            <p>
+                Things MAY be bundled together with a Consumer to enable Thing-to-Thing interaction.
+                The configuration of the Consumer behavior MAY be exposed through the Thing.
+                or MAY be defined out of band, for instance, within
+
                 <a href="#architecture-abstract"></a> shows an overview
                 of how these WoT concepts can be mapped to various
                 components and devices in a connected system.
@@ -1569,56 +1572,68 @@ a[href].internalDFN {
             <figure id="architecture-abstract">
                 <img src="images/architecture-abstract-new.png"
                     style="width: 100%;" />
-                <figcaption>Abstract Architecture of W3C
-                    WoT</figcaption>
+                <figcaption>Abstract Architecture of W3C WoT</figcaption>
             </figure>
+        </section>
+        <section>
+            <h2>Affordances</h2>
+            <p>
+                A central aspect in the concept of Web Things is the provision of machine-understandable metadata.
+                Ideally, such metadata is self-descriptive, so that <a>Consumers</a> are able to identify
+                <emph>what</emph> capabilities a Thing provides and <emph>how</emph> they can make use the provided capabilities.
+                A key to this self-descriptiveness lies in the concept of affordances.
+            </p>
+            <p>The term affordance originates in ecological
+                psychology, but was adopted in the field of
+                Human-Computer Interaction [[?HCI]] based on the
+                definition by Donald Norman: "'Affordance' refers to
+                the perceived and actual properties of the thing,
+                primarily those fundamental properties that
+                determine just how the thing could possibly be
+                used." [[?NORMAN]]</p>
+            <p>
+                An example for this is a door having a handle.
+                The door handle is an affordance, which suggests that the door can be opened.
+                For humans, a door handle usually also suggests how the door is opened;
+                an American knob suggests twisting, a European lever handle suggests pressing down.
+            </p>
+            <p>
+                The hypermedia principle, which is one of the
+                bedrock foundations of the REST architectural style [[?REST]],
+                demands that any piece of information available on
+                the Web be linked to other pieces of information so
+                that the consumer of the information gets explicit
+                knowledge about how to navigate the Web and control
+                Web applications.
+                Here, the simultaneous presentation of
+                information and control (provided in
+                the form of hyperlinks) is a mechanism that affords
+                Web clients the means to drive Web applications. In this
+                context, an affordance is the description of a
+                hyperlink (e.g. via a link relation type and link
+                target attributes) suggesting Web clients how to navigate
+                and possibly how act on the linked resource.
+            </p>
+            <p>
+                Drawn from this hypermedia principle,
+                the Web of Things defines <a>Interaction Affordances</a> as metadata of a Thing
+                that shows and describes the possible choices to <a>Consumers</a>, thereby suggesting how <a>Consumers</a> may interact with the Thing.
+                A general <a>Interaction Affordances</a> is navigation, which is activated by following links, thereby browsing the Web of Things.
+                <a href="#sec-interaction-model"></a> defines three more types of Interaction Affordances for W3C WoT: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
+            </p>
+            <p>
+                This definition is thereby aligned with HCI and interaction designers, who create physical Things,
+                as well as the REST and microservice community, who is working on Web services in general.
+            </p>
         </section>
         <section id="sec-web-thing">
             <h2>Web Thing</h2>
-            <p>A simple example is a Thing being the digital
-                representation of a physical IoT devices, which also
-                directly provides the interface for interaction. A Thing
-                may also be hosted on a gateway or the cloud,
-                representing a physical entity with which clients cannot
-                communicate directly (e.g., a legacy device) or not all
-                (e.g., a room or table). Virtual entities like a room
-                are often represented by a composition of one or more
-                sensors and actuators, each of which may also be
-                available as an individual Thing.</p>
             <p>
-                A <a>Thing</a> in the Web of Things is the abstraction
-                of a physical or a virtual entity whose metadata and
-                interfaces are described by a WoT Thing Description. A
-                virtual entity is the composition of one or more Things.
-            </p>
-            <p>A simple example is a Thing being the digital
-                representation of a physical IoT devices, which also
-                directly provides the interface for interaction. A Thing
-                may also be hosted on a gateway or the cloud,
-                representing a physical entity with which clients cannot
-                communicate directly (e.g., a legacy device) or not all
-                (e.g., a room or table). Virtual entities like a room
-                are often represented by a composition of one or more
-                sensors and actuators, each of which may also be
-                available as an individual Thing.</p>
-            <p>
-                The interface of a <a>Thing</a> must follow the
-                interaction model of the WoT Architecture. However, <a>Things</a>
-                may only consist of metadata without offering an
-                interface for interaction.
-            </p>
-        </section>
-        <section id="sec-arch-aspects">
-            <h2>Architectural Aspects of a Web Thing</h2>
-            <p>
-                The use cases and the requirements discussed result in
-                an abstract model of a Thing that has four architectural
-                aspects of interest: its behavior, its interactions, the
-                mapping of those interactions to concrete protocols
-                (what we call the Protocol Binding), and its security
+                A Web Thing has four architectural
+                aspects of interest: its behavior, its <a>Interaction Affordances</a>, and its security
                 configuration. See <a href="#arch-aspects"></a>. The
                 behavior aspect of a Thing includes both lifecycle
-                management (onboarding, updating, decommissioning, etc)
+                management (onboarding, updating, decommissioning, etc.)
                 but also the operational behavior of the Thing, which
                 can include both autonomous behavior and support for
                 interactions. Interactions have two parts, the
@@ -1642,16 +1657,15 @@ a[href].internalDFN {
             </p>
             <figure id="arch-aspects">
                 <img src="images/wot-abstract-arch.png" />
-                <figcaption>Architectural Aspects of a
-                    Thing</figcaption>
+                <figcaption>Architectural Aspects of a Thing</figcaption>
             </figure>
         </section>
         <section id="sec-interaction-model">
             <h2>Interaction Model</h2>
             <p>Originally, a Web resource usually represented a
                 document on the World Wide Web that can simply be
-                fetched by a client. With the introduction of Web
-                services, resources became more generic with interaction
+                fetched by a Web client. With the introduction of Web
+                services, resources became more generic interaction
                 endpoints that can implement any kind of behavior. This
                 very high level of abstraction makes it hard to provide
                 a loose coupling between applications and the manifold
@@ -1670,45 +1684,6 @@ a[href].internalDFN {
                 into three different behaviors, the three types are
                 still able to cover virtually all functionality found in
                 IoT devices and services.</p>
-            <section>
-                <h3>Interaction Affordances</h3>
-                <p>The term affordance originates in ecological
-                    psychology, but was adopted in the field of
-                    Human-Computer Interaction [[?HMI]] based on the
-                    definition by Donald Norman: "'Affordance' refers to
-                    the perceived and actual properties of the thing,
-                    primarily those fundamental properties that
-                    determine just how the thing could possibly be
-                    used." [[?NORMAN]]</p>
-                <p>The hypermedia principle that is one of the
-                    bedrock foundations of the REST [[?REST]] principle
-                    demands that any piece of information available on
-                    the Web be linked to other pieces of information so
-                    that the consumer of the information gets explicit
-                    knowledge about how to navigate the Web and control
-                    Web applications. The simultaneous presentation to
-                    Web clients of information and control, provided in
-                    the form of hyperlinks, is a mechanism that affords
-                    clients the means to drive Web applications. In this
-                    context, an affordance is the description of a
-                    hyperlink (e.g. via a link relation type or link
-                    target attributes) suggesting clients how to act on
-                    the linked resource.</p>
-                <p>
-                    Drawn from this hypermedia principle, the Web of
-                    Things defines Interaction Affordances as metadata
-                    of a Thing exposing <a>hypermedia control</a>s that
-                    describe the possible protocol-level choices to
-                    clients, thereby suggesting how clients may interact
-                    with the Thing. Examples use of affordances
-                    includes, but are not limited, getting and setting <a>properties</a>,
-                    invoking <a>actions</a>, and subscribing to <a>events</a>.
-                </p>
-                <p>This definition is thereby aligned with HCI and
-                    interaction designers, who create physical Things,
-                    as well as the REST and microservice community
-                    working on Web services in general.</p>
-            </section>
             <section>
                 <h3>Properties</h3>
                 <p>A Property is an Interaction Affordance that
@@ -1957,12 +1932,11 @@ a[href].internalDFN {
         </section>
         <section id="sec-protocol-bindings">
             <h2>Protocol Bindings</h2>
-            <p>A Protocol Binding is set of mapping rules from an
-                Interaction Affordance to concrete messages of a
-                specific protocol such as HTTP [[!RFC7231]], CoAP
-                [[!RFC7252]], or MQTT [[!MQTT]]. The Protocol Bindings
-                follow the Uniform Interface constraint of REST
-                [[?REST]].</p>
+            <p>
+                A Protocol Binding is the mapping from an Interaction Affordance to concrete messages of a specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]].
+                The Protocol Bindings follow the Uniform Interface constraint of REST [[?REST]] to support interoperability
+                and are serialized as hypermedia controls to be self-descriptive.
+            </p>
             <section>
                 <h3>Hypermedia-driven</h3>
                 <p>
@@ -1985,58 +1959,57 @@ a[href].internalDFN {
                         determine the freshness.</span>
                 </p>
             </section>
-
-        </section>
-        <section id="sec-arch-URIs">
-            <h3>URIs</h3>
-            <p>
-                <span class="rfc2119-assertion" id="arch-uri-scheme">Eligible
-                    protocols for the Web of Things MUST have an
-                    associated URI scheme that is registered with IANA
-                    [[!RFC4395]].</span> Hypermedia controls rely on URIs to
-                identify target resources and submission targets.
-                Thereby, the URI scheme (the first component up to ":")
-                identifies the communication protocol to be used for
-                interaction with the Thing. The Web of Things refers to
-                these protocols as <a>transfer protocols</a>.
-            </p>
-        </section>
-        <section id="sec-standard-method">
-            <h3>Standard Set of Methods</h3>
-            <p>
-                <span class="rfc2119-assertion" id="arch-methods">Eligible
-                    protocols for the Web of Things MUST be based on a
-                    standard set of methods that can be shared a priori.</span>
-                The standard set of methods makes messages
-                self-descriptive to enable intermediate processing of
-                interactions, for instance by proxies or to translate
-                between Protocol Bindings [[?REST]]. Furthermore, it
-                allows clients to have application-agnostic protocol
-                stack, avoiding Thing-specific code or plugins.
-            </p>
-        </section>
-        <section id="media-types">
-            <h3>Media Types</h3>
-            <p>
-                <span class="rfc2119-assertion" id="arch-media-type">All
-                    data (a.k.a. content) exchanged within Interaction
-                    Affordances MUST be identified by a Media Type
-                    [[!RFC6838]].</span> Media Types are IANA-managed labels to
-                identify representation formats, for instance
-                <code>application/json</code>
-                for JSON [[!RFC7159]] or
-                <code>application/cbor</code>
-                for CBOR [[!RFC7049]].
-            </p>
-            <p>
-                Note that many Media Types only identify a generic
-                serialization format that does not provide further
-                semantics for its elements (e.g., XML, JSON, CBOR). <span
-                    class="rfc2119-assertion" id="arch-schema">Thus,
-                    the corresponding Interaction Affordances SHOULD
-                    declare a data schema to provide more detailed
-                    semantic metadata for the data exchanged.</span>
-            </p>
+            <section id="sec-arch-URIs">
+                <h3>URIs</h3>
+                <p>
+                    <span class="rfc2119-assertion" id="arch-uri-scheme">Eligible
+                        protocols for the Web of Things MUST have an
+                        associated URI scheme that is registered with IANA
+                        [[!RFC4395]].</span> Hypermedia controls rely on URIs to
+                    identify target resources and submission targets.
+                    Thereby, the URI scheme (the first component up to ":")
+                    identifies the communication protocol to be used for
+                    interaction with the Thing. The Web of Things refers to
+                    these protocols as <a>transfer protocols</a>.
+                </p>
+            </section>
+            <section id="sec-standard-method">
+                <h3>Standard Set of Methods</h3>
+                <p>
+                    <span class="rfc2119-assertion" id="arch-methods">Eligible
+                        protocols for the Web of Things MUST be based on a
+                        standard set of methods that can be shared a priori.</span>
+                    The standard set of methods makes messages
+                    self-descriptive to enable intermediate processing of
+                    interactions, for instance by proxies or to translate
+                    between Protocol Bindings [[?REST]]. Furthermore, it
+                    allows clients to have application-agnostic protocol
+                    stack, avoiding Thing-specific code or plugins.
+                </p>
+            </section>
+            <section id="media-types">
+                <h3>Media Types</h3>
+                <p>
+                    <span class="rfc2119-assertion" id="arch-media-type">All
+                        data (a.k.a. content) exchanged within Interaction
+                        Affordances MUST be identified by a Media Type
+                        [[!RFC6838]].</span> Media Types are IANA-managed labels to
+                    identify representation formats, for instance
+                    <code>application/json</code>
+                    for JSON [[!RFC7159]] or
+                    <code>application/cbor</code>
+                    for CBOR [[!RFC7049]].
+                </p>
+                <p>
+                    Note that many Media Types only identify a generic
+                    serialization format that does not provide further
+                    semantics for its elements (e.g., XML, JSON, CBOR). <span
+                        class="rfc2119-assertion" id="arch-schema">Thus,
+                        the corresponding Interaction Affordances SHOULD
+                        declare a data schema to provide more detailed
+                        semantic metadata for the data exchanged.</span>
+                </p>
+            </section>
         </section>
         <section id="sec-WoT-servient-architecture-high-level">
             <h2>System Configurations</h2>

--- a/index.html
+++ b/index.html
@@ -1693,7 +1693,7 @@ a[href].internalDFN {
             </p>
             <p>
                 In addition to navigation affordances (i.e., Web links),
-                <a>Things</a> MAY only offer three other types of <a>Interaction Affordances</a>: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
+                <a>Things</a> MAY offer three other types of <a>Interaction Affordances</a> defined by this document: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
                 While this narrow waist allows to decouple <a>Consumers</a> and <a>Things</a>,
                 these four types of <a>Interaction Affordances</a> are still able to model virtually all interaction possibilities found in IoT devices and services.
             </p>

--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@ a[href].internalDFN {
                 Things (provide access to locally gathered data or
                 computed from consumed Things, provide remote control
                 and management interfaces). The application can be
-                implemented using the Scripting API or native platform
+                implemented using the WoT Scripting API or native platform
                 APIs. The application may also be distributed over
                 multiple Things and other hosts.</dd>
             <dt>
@@ -364,8 +364,8 @@ a[href].internalDFN {
             <dt>
                 <dfn>to consume a Thing</dfn>
             </dt>
-            <dd>To read a Thing Description and create a Consumed
-                Thing software object for the application in the local
+            <dd>To process a Thing Description and from it create a Consumed
+                Thing software abstraction as interface for the application in the local
                 runtime environment.</dd>
             <dt>
                 <dfn>Consumed Thing</dfn>
@@ -373,7 +373,7 @@ a[href].internalDFN {
             <dd>A software abstraction that represents a remote
                 Thing used by the local application. The abstraction might be
                 created by a native WoT Runtime, or instantiated
-                as an object by a Scripting API implementation.</dd>
+                as an object through the WoT Scripting API.</dd>
             <dt>
                 <dfn>Consumer</dfn>
             </dt>
@@ -400,7 +400,6 @@ a[href].internalDFN {
                 enterprise or service provider core networks. Examples
                 include gateways, routers, switches, multiplexers, and a
                 variety of other access devices.</dd>
-            
             <dt>
                 <dfn>Event</dfn>
             </dt>
@@ -415,19 +414,16 @@ a[href].internalDFN {
             <dt>
                 <dfn>to expose a Thing</dfn>
             </dt>
-            <dd>To create an Exposed Thing software object in the
-                local runtime environment that enables the application
-                to provide local state and calls as Interactions over
-                the network.</dd>
+            <dd>To create an Exposed Thing software abstraction in the
+                local runtime environment to manage the state of a Thing
+                and interface with the behavior implementation.</dd>
             <dt>
                 <dfn>Exposed Thing</dfn>
             </dt>
-            <dd>A software abstraction that represents a Thing 
-                implemented locally that be accessed over the network by remote
-                Consumers. 
-                The abstraction might be
-                created by a native WoT Runtime, or instantiated
-                as an object by a Scripting API implementation.</dd>
+            <dd>A software abstraction that represents a locally hosted Thing 
+                that can be accessed over the network by remote Consumers. 
+                The abstraction might be created by a native WoT Runtime,
+                or instantiated as an object through the WoT Scripting API.</dd>
             <dt>
                 <dfn>Hypermedia Control</dfn>
             </dt>
@@ -443,13 +439,20 @@ a[href].internalDFN {
                 thereby suggesting how Consumers may interact with the Thing.
                 There are many types of potential affordances, but 
                 W3C WoT defines three types of Interaction Affordances:
-                Properties, Actions, and Events.</dd>
+                Properties, Actions, and Events.
+                A fourth Interaction Affordance is navigation, which is already available on the Web through linking.</dd>
             <dt>
                 <dfn>Interaction Model</dfn>
             </dt>
-            <dd>An intermediate abstraction that formalizes the
-                mapping from application intent to concrete protocol
-                bindings, which are used to interact with Web resources.</dd>
+            <dd>An intermediate abstraction that formalizes and narrows the
+                mapping from application intent to concrete protocol operations.
+                In W3C WoT, the defined set of Interaction Affordances constitutes the Interaction Model.</dd>
+            <dt>
+                <dfn>Intermediary</dfn>
+            </dt>
+            <dd>An entity between Consumers and Things that can proxy, augment, or compose things
+                and republish a Thing Description that points to the WoT Interface on the Intermediary instead of the original Thing.
+                For Consumers, an Intermediary may be indistinguishable from a Thing, following the Layered System constraint of REST.</dd>
             <dt>
                 <dfn>IoT platform</dfn>
             </dt>
@@ -474,8 +477,8 @@ a[href].internalDFN {
                 <dfn>Scripting Runtime</dfn>
             </dt>
             <dd>A runtime system that is used for implementing an
-                API in a scripting language (e.g. using ECMAScript, LUA,
-                Python etc.).</dd>
+                API in a scripting language (e.g., using ECMAScript, LUA,
+                Python, etc.).</dd>
             <dt>
                 <dfn>Servient</dfn>
             </dt>
@@ -487,7 +490,8 @@ a[href].internalDFN {
                 <dfn>Subprotocol</dfn>
             </dt>
             <dd>An extension mechanism to a transfer protocol that
-                must be known to interact successfully.</dd>
+                must be known to interact successfully.
+                An example is long polling for HTTP.</dd>
             <dt>
                 <dfn>TD</dfn>
             </dt>
@@ -507,27 +511,18 @@ a[href].internalDFN {
                 Thing Description, whereas a virtual entity is the
                 composition of one or more Things.</dd>
             <dt>
-                <dfn data-lt="WoT Thing Description">Thing
-                    Description</dfn>
-            </dt>
-            <dd>Structured data describing a Thing. A TD includes
-                metadata, domain-specific metadata, a list of offered
-                interactions, the supported protocol bindings for each
-                interaction, and links to related Things. The Thing
-                Description is built around a formal Interaction Model.</dd>
-            <dt>
                 <dfn>Thing Directory</dfn>
             </dt>
             <dd>A directory service for TDs that provides a Web
-                interface to register TDs (see [[CoRE-RD]]) and look
-                them up (e.g., using SPARQL queries or CoRE Link
-                Format).</dd>
+                interface to register TDs (similar to [[?CoRE-RD]]) and look them up
+                (e.g., using SPARQL queries or the CoRE RD lookup interface [[?CoRE-RD]]).</dd>
             <dt>
                 <dfn>Transfer Protocol</dfn>
             </dt>
             <dd>The underlying, standardized application layer
-                protocol without application-specific options or
-                subprotocol mechanisms.</dd>
+                protocol without application-specific requirements or
+                constraints on options or subprotocol mechanisms.
+                Examples are HTTP, CoAP, or MQTT.</dd>
             <dt>
                 <dfn>Virtual Thing</dfn>
             </dt>
@@ -542,30 +537,29 @@ a[href].internalDFN {
                 <dfn>WoT Runtime</dfn>
             </dt>
             <dd>A runtime system that maintains an execution
-                environment for applications, and is able to expose and
-                optionally consume TDs, offers a protocol binding to one
-                or more protocols, and maintains private security
-                metadata.</dd>
+                environment for applications, and is able to expose and/or
+                consume Things, to process Thing Descriptions, to maintain private security
+                metadata, and to interface with Protocol Binding implementations.
+                A WoT Runtime may have a custom API or use the optional WoT Scripting API.</dd>
             <dt>
                 <dfn>WoT Scripting API</dfn>
-                or the
-                <dfn>Scripting API</dfn>
             </dt>
             <dd>The application-facing programming interface
-                optionally provided by a Servient in order to to ease
-                the implementation of applications running in a WoT
-                Runtime. It is comparable to the Web browser APIs.</dd>
-            <dt>
-                <dfn>WoT Server</dfn>
-            </dt>
-            <dd>An entity that exposes a network interface
-                consistent with a WoT Thing Description. WoT Server is
-                also used to refer to a Servient in server role only.</dd>  
+                provided by a Servient in order to to ease
+                the implementation of behavior or applications running in a WoT
+                Runtime. It is comparable to the Web browser APIs.
+                The WoT Scripting API is an optional building block for W3C WoT.</dd>
             <dt>
                 <dfn>WoT Servient</dfn>
-                <dd>Synonym for Servient.</dd>
             </dt>
-            <dd>
+            <dd>Synonym for Servient.</dd>
+            <dt>
+                <dfn>WoT Thing Description</dfn> or <dfn>Thing Description</dfn>
+            </dt>
+            <dd>Structured data describing a Thing. A Thing Description comprises
+                general metadata, domain-specific metadata, Interaction Affordances
+                (which include the supported Protocol Bindings), and links to related Things.
+                The WoT Thing Description is the central building block of W3C WoT.</dd>
         </dl>
     </section>
 
@@ -1505,15 +1499,15 @@ a[href].internalDFN {
         <p>
             <em>This section is normative.</em>
         </p>
-
         <section id="sec-architecture-overview">
             <h2>Overview</h2>
             <p>
                 To address the use cases in Section 4 and fulfill the requirements in Section 5,
-                the Web of Things builds on top of the concept of Web Things -- usually simply called <a>Things</a> -- that can be used by so-called <a>Consumers</a>.
+                the Web of Things (WoT) builds on top of the concept of Web Things &ndash; usually simply called <a>Things</a> &ndash; that can be used by so-called <a>Consumers</a>.
                 A Thing is the abstraction of a physical or virtual entity (e.g., a device or a room, resp.)
                 and is described by standardized metadata.
                 In W3C WoT, the description metadata MUST be a WoT Thing Description [[!wot-thing-description]].
+                <a>Consumers</a> MUST be able to process the WoT Thing Description format, which is based on JSON [[!rfc8259]].
                 A Thing Description (TD) is instance-specific (i.e., describes an individual Thing, not types of Things)
                 and is the default Web representation of a Thing.
                 There MAY be other Web representations of a Thing such as an HTML-based user interface or simply an image of the physical entity.
@@ -1572,8 +1566,9 @@ a[href].internalDFN {
                 The configuration of the Consumer behavior MAY be exposed through the Thing.
             </p>
             <p>
-                <a href="#architecture-abstract"></a> summarizes how the WoT concepts introduced above can be applied and combined to address the use cases summarized in <a href="#sec-use-case-summary"></a>.
-                In particular, W3C WoT is applicable to all levels relevant for IoT applications: the device level, edge level, and cloud level.
+                The concepts of W3C WoT are applicable to all levels relevant for IoT applications: the device level, edge level, and cloud level.
+                This fosters common interfaces and APIs across the different levels and enables various integration patterns such as Thing-to-Thing, Thing-to-gateway, Thing-to-cloud, gateway-to-cloud, and even cloud federation for IoT applications.
+                <a href="#architecture-abstract"></a> gives an overview how the WoT concepts introduced above can be applied and combined to address the use cases summarized in <a href="#sec-use-case-summary"></a>.
             </p>
             <figure id="architecture-abstract">
                 <img src="images/architecture-abstract-new.png"
@@ -1584,12 +1579,13 @@ a[href].internalDFN {
         <section>
             <h2>Affordances</h2>
             <p>
-                A central aspect in the concept of Web Things is the provision of machine-understandable metadata.
+                A central aspect in W3C WoT is the provision of machine-understandable metadata (i.e., <a>Thing Descriptions</a>).
                 Ideally, such metadata is self-descriptive, so that <a>Consumers</a> are able to identify
-                <emph>what</emph> capabilities a Thing provides and <emph>how</emph> they can make use the provided capabilities.
+                <emph>what</emph> capabilities a <a>Thing</a> provides and <emph>how</emph> to use the provided capabilities.
                 A key to this self-descriptiveness lies in the concept of affordances.
             </p>
-            <p>The term affordance originates in ecological
+            <p>
+                The term affordance originates in ecological
                 psychology, but was adopted in the field of
                 Human-Computer Interaction [[?HCI]] based on the
                 definition by Donald Norman: "'Affordance' refers to
@@ -1598,9 +1594,9 @@ a[href].internalDFN {
                 determine just how the thing could possibly be
                 used." [[?NORMAN]]</p>
             <p>
-                An example for this is a door having a handle.
+                An example for this is a door with a handle.
                 The door handle is an affordance, which suggests that the door can be opened.
-                For humans, a door handle usually also suggests how the door is opened;
+                For humans, a door handle usually also suggests <emph>how</emph> the door can be opened;
                 an American knob suggests twisting, a European lever handle suggests pressing down.
             </p>
             <p>
@@ -1613,22 +1609,22 @@ a[href].internalDFN {
                 Web applications.
                 Here, the simultaneous presentation of
                 information and control (provided in
-                the form of hyperlinks) is a mechanism that affords
+                the form of hyperlinks) is a mechanism that <emph>affords</emph>
                 Web clients the means to drive Web applications. In this
                 context, an affordance is the description of a
-                hyperlink (e.g. via a link relation type and link
+                hyperlink (e.g., via a link relation type and link
                 target attributes) suggesting Web clients how to navigate
-                and possibly how act on the linked resource.
+                and possibly how to act on the linked resource.
             </p>
             <p>
                 Drawn from this hypermedia principle,
                 the Web of Things defines <a>Interaction Affordances</a> as metadata of a Thing
-                that shows and describes the possible choices to <a>Consumers</a>, thereby suggesting how <a>Consumers</a> may interact with the Thing.
-                A general <a>Interaction Affordances</a> is navigation, which is activated by following links, thereby browsing the Web of Things.
+                that shows and describes the possible choices to <a>Consumers</a>, thereby suggesting how <a>Consumers</a> may interact with the <a>Thing</a>.
+                A general <a>Interaction Affordance</a> is navigation, which is activated by following a link, thereby enabling <a>Consumers</a> to browse the Web of Things.
                 <a href="#sec-interaction-model"></a> defines three more types of Interaction Affordances for W3C WoT: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
             </p>
             <p>
-                This definition is thereby aligned with HCI and interaction designers, who create physical Things,
+                Overall, this W3C WoT definition is aligned with HCI and interaction designers, who create physical Things,
                 as well as the REST and microservice community, who is working on Web services in general.
             </p>
         </section>
@@ -1668,77 +1664,85 @@ a[href].internalDFN {
         </section>
         <section id="sec-interaction-model">
             <h2>Interaction Model</h2>
-            <p>Originally, a Web resource usually represented a
+            <p>
+                Originally, a Web resource usually represented a
                 document on the World Wide Web that can simply be
                 fetched by a Web client. With the introduction of Web
                 services, resources became more generic interaction
-                endpoints that can implement any kind of behavior. This
+                entities that can implement any kind of behavior. This
                 very high level of abstraction makes it hard to provide
                 a loose coupling between applications and the manifold
-                interaction possibilities of resources. As a result,
-                typical API descriptions consist of a static mapping
+                of interaction possibilities for resources. As a result,
+                at the time of writing typical API descriptions consist of a static mapping
                 from an application intent to a resource address,
                 method, request payload structure, response payload
-                structure, and expected errors.</p>
-            <p>The interaction model of WoT introduces an
+                structure, and expected errors.
+                This imposes a tight coupling between Web client and Web service.</p>
+            <p>
+                The <a>Interaction Model</a> of W3C WoT introduces an
                 intermediate abstraction that formalizes the mapping
-                from application intent to concrete protocol bindings,
-                which are used to interact with Web resources. Instead
-                of generic resources, WoT applications use three types
-                of so-called Interaction Affordances: Properties,
-                Actions, and Events. While constraining Web resources
-                into three different behaviors, the three types are
-                still able to cover virtually all functionality found in
-                IoT devices and services.</p>
+                from application intent to concrete protocol operations
+                and also narrows the possibilities how Interactions
+                can be modeled.
+            </p>
+            <p>
+                In addition to navigation affordances (i.e., Web links),
+                <a>Things</a> MAY only offer three other types of <a>Interaction Affordances</a>: Properties, Actions, and Events.
+                While this narrow waist allows to decouple <a>Consumers</a> and <a>Things</a>,
+                these four types of <a>Interaction Affordances</a> are still able to model virtually all interaction possibilities found in IoT devices and services.
+            </p>
             <section>
                 <h3>Properties</h3>
-                <p>A Property is an Interaction Affordance that
-                    exposes internal state of the Thing that can be
-                    directly accessed (read) and optionally manipulated
-                    (write). Things can also choose to make Properties
-                    observable by pushing the new state after a change
-                    (cf. CoAP Observe [[?RFC7641]]).</p>
-                <p>Properties may contain one data schema if the
-                    data is not fully specified by the Protocol Binding
-                    used (e.g., through a Media Type).</p>
-                <p>Examples of Properties are sensor values
-                    (read-only), stateful actuators (read-write),
-                    configuration parameters (read-write), Thing status
-                    (read-only), or computation results (read-only).</p>
+                <p>
+                    A Property is an Interaction Affordance that exposes state of the Thing
+                    that MUST be retrievable (read) and optionally MAY be updated (write).
+                    Things MAY choose to make Properties observable by pushing the new state after a change
+                    (cf. Observing Resources [[?RFC7641]]).
+                    Write-only state SHOULD be exposed through an Action.
+                </p>
+                <p>
+                    Properties MAY contain one data schema if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type).
+                </p>
+                <p>
+                    Examples of Properties are sensor values (read-only), stateful actuators (read-write),
+                    configuration parameters (read-write), Thing status (read-only or read-write), or computation results (read-only).
+                </p>
             </section>
             <section>
                 <h3>Actions</h3>
-                <p>An Action is an Interaction Affordance that
-                    allows to invoke a function of the Thing, which
-                    manipulates internal state that is not directly
-                    exposed (cf. Properties) based on internal logic or
-                    triggers a process on the Thing.</p>
-                <p>Actions may contain up to two data schemas, one
-                    for optional input parameters, one for output
-                    results, if the data is not fully specified by the
-                    Protocol Binding used (e.g., through a Media Type).</p>
-                <p>Examples of Actions are changing multiple
-                    Properties simultaneously, changing Properties over
-                    time or with a process that shall not be disclosed,
-                    or invoking a long-lasting process such as actuator
-                    control.</p>
+                <p>
+                    An Action is an Interaction Affordance that allows to invoke a function of the Thing,
+                    which MAY manipulate state that is not directly exposed (cf. Properties),
+                    manipulate multiple Properties at a time, or manipulate Properties based on internal logic (e.g., toggle).
+                    Invoking an Action MAY also trigger a process on the Thing that manipulates state (including physical state through actuators) over time.
+                </p>
+                <p>
+                    Actions MAY contain up to two data schemas,
+                    one for optional input parameters and one for output results,
+                    if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type).
+                </p>
+                <p>
+                    Examples of Actions are changing multiple Properties simultaneously,
+                    changing Properties over time such as fading the brightness of a light (dimming)
+                    or with a process that shall not be disclosed such as a proprietary control loop algorithm,
+                    or invoking a long-lasting process such as priting a document.</p>
             </section>
             <section>
                 <h3>Events</h3>
-                <p>An Event Interaction Affordance describes
-                    asynchronous push interactions initiated by the
-                    Thing. Here not state, but state transitions (i.e.,
-                    events) are communicated. Events may be triggered
-                    through conditions that are not exposed as
-                    Properties.</p>
-                <p>Events may contain up to three data schemas, one
-                    for the event data and optionally one for the
-                    subscription data and/or one for the cancellation
-                    data, if the data is not fully specified by the
-                    Protocol Binding used (e.g., through a Media Type).</p>
-                <p>Examples of Events are discrete events such as an
-                    alarm or samples of a time series that are pushed
-                    regularly.</p>
+                <p>
+                    An Event Interaction Affordance describes an event source that pushes data asynchronously from the Thing to the Consumer.
+                    Here not state, but state transitions (i.e., events) are communicated.
+                    Events MAY be triggered through conditions that are not exposed as Properties.
+                </p>
+                <p>
+                    Events MAY contain up to three data schemas,
+                    one for the event data if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type),
+                    optionally one for the subscription data if the message to subscribe is not implicitly known from the Protocol Binding used (e.g., Server-Sent Events vs Web hooks),
+                    and optionally one for the cancellation data if the messages to unsubscribe is not implicitly known from the Protocol Binding used (e.g., WebSockets vs Web hooks).
+                </p>
+                <p>
+                    Examples of Events are discrete events such as an alarm or samples of a time series that are pushed regularly.
+                </p>
             </section>
         </section>
         <section id="sec-hypermedia-controls">
@@ -2133,7 +2137,7 @@ a[href].internalDFN {
             are highlighted with black outlines.
             Security, a cross-cutting concern, 
             is separated into public and protected private components. 
-            The WoT Scripting API is optional and the
+            The <a>WoT Scripting API</a> is optional and the
             Binding Templates are informative.
         </p>
         <figure id="arch-building-blocks">
@@ -2348,12 +2352,12 @@ a[href].internalDFN {
         </section>
         <section id="sec-scripting-api" class="informative">
             <h3>WoT Scripting API</h3>
-            <p> The <a>Scripting API</a> is an optional "convenience"
+            <p> The <a>WoT Scripting API</a> is an optional "convenience"
                 building block in WoT that eases IoT application
                 development and is implemented using a Scripting Runtime
                 (such as a Python, Lua or ECMAScript implementation)
                 that is used in combination with a <a>WoT Runtime</a>.
-                The Scripting API enables writing WoT applications by
+                The <a>WoT Scripting API</a> enables writing WoT applications by
                 user-defined scripts.
             </p>
             <p> Traditionally, IoT device logic is implemented in
@@ -2371,11 +2375,11 @@ a[href].internalDFN {
                 time-critical logic from the cloud down to a gateway or
                 edge node.
             </p>
-            <p> The non-normative WoT Scripting API document defines
+            <p> The non-normative <a>WoT Scripting API</a> document defines
                 the structure and algorithms of the programming
                 interface that allows scripts to discover, consume
                 (retrieve) and produce (define) Thing Descriptions. The
-                implementation of the Scripting API instantiates local
+                implementation of the <a>WoT Scripting API</a> instantiates local
                 objects that act as an interface to other Things and
                 represents their Interaction Affordances (Properties,
                 Actions, and Events). It also allows scripts to expose
@@ -2396,7 +2400,7 @@ a[href].internalDFN {
                 architecture, security is supported by certain explicit
                 features, such as support for public security metadata in TDs
                 and by separation of concerns in the design of the
-                Scripting API. The documents defining each building
+                <a>WoT Scripting API</a>. The documents defining each building
                 block also include a discussion of particular security
                 and privacy considerations for each building block.
                 Another set of documents, the WoT Security and Privacy
@@ -2425,10 +2429,10 @@ a[href].internalDFN {
             abstract architecture. When implementing these concepts, a
             more detailed view is necessary that takes certain technical
             aspects into account. The detailed architecture of a <a>Servient</a>
-            implementation using the (optional) WoT Scripting API is
+            implementation using the (optional) <a>WoT Scripting API</a> is
             shown in <a href="#architecture-implementation"></a>.
             This figure shows and implementation that is using the optional 
-            WoT Scripting API. 
+            <a>WoT Scripting API</a>. 
             Scripts are actually executed by a nested Scripting Runtime, 
             while WoT-specific Servient Implementation aspects are managed
             by the WoT Runtime. 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                 publisher : "OASIS Standard",
                 date : "2014"
             },
-            "FORMS" : {
+            "CoRAL" : {
                 href : "https://tools.ietf.org/html/draft-hartke-t2trg-coral",
                 title : "The Constrained RESTful Application Language (CoRAL)",
                 author : "Klaus Hartke",
@@ -1499,18 +1499,21 @@ a[href].internalDFN {
         <p>
             <em>This section is normative.</em>
         </p>
+        <p>
+            To address the use cases in Section 4 and fulfill the requirements in Section 5,
+            the Web of Things (WoT) builds on top of the concept of Web Things &ndash; usually simply called <a>Things</a> &ndash; that can be used by so-called <a>Consumers</a>.
+            This section provides the background and normative assertions to define the overall W3C Web of Things architecture.
+            As the Web of Things addresses stakeholders from different domains, certain aspects of Web technology are explained in more detail, in particular the concept of hypermedia.
+        </p>
         <section id="sec-architecture-overview">
             <h2>Overview</h2>
-            <p>
-                To address the use cases in Section 4 and fulfill the requirements in Section 5,
-                the Web of Things (WoT) builds on top of the concept of Web Things &ndash; usually simply called <a>Things</a> &ndash; that can be used by so-called <a>Consumers</a>.
-                A Thing is the abstraction of a physical or virtual entity (e.g., a device or a room, resp.)
-                and is described by standardized metadata.
+                A <a>Thing</a> is the abstraction of a physical or virtual entity (e.g., a device or a room, resp.) and is described by standardized metadata.
                 In W3C WoT, the description metadata MUST be a WoT Thing Description (TD) [[!wot-thing-description]].
-                <a>Consumers</a> MUST be able to process the <a>WoT Thing Description</a> format, which is based on JSON [[!rfc8259]].
+                <a>Consumers</a> MUST be able to process the <a>WoT Thing Description</a> format, which is based on JSON [[!RFC8259]].
+                The format can be processed either through classic JSON libraries or a JSON-LD processor, as the underlying information model is graph-based and its serialization compatible with JSON-LD 1.1 [[?json-ld-syntax]].
                 A <a>TD</a> is instance-specific (i.e., describes an individual Thing, not types of Things)
-                and is the default Web representation of a Thing.
-                There MAY be other Web representations of a Thing such as an HTML-based user interface or simply an image of the physical entity.
+                and is the default Web representation of a <a>Thing</a>.
+                There MAY be other Web representations of a <a>Thing</a> such as an HTML-based user interface or simply an image of the physical entity.
                 However, the <a>WoT Thing Description</a> is a standardized, machine-understandable representation format
                 that allows <a>Consumers</a> to discover and interpret the capabilities of a Thing (through semantic annotations)
                 and to adapt to different implementations (e.g., different protocols or data structures) when interacting with a Thing,
@@ -1575,7 +1578,7 @@ a[href].internalDFN {
                 <figcaption>Abstract Architecture of W3C WoT</figcaption>
             </figure>
         </section>
-        <section>
+        <section id="sec-affordances">
             <h2>Affordances</h2>
             <p>
                 A central aspect in W3C WoT is the provision of machine-understandable metadata (i.e., <a>WoT Thing Descriptions</a>).
@@ -1670,8 +1673,8 @@ a[href].internalDFN {
                 services, resources became more generic interaction
                 entities that can implement any kind of behavior. This
                 very high level of abstraction makes it hard to provide
-                a loose coupling between applications and the manifold
-                of interaction possibilities for resources. As a result,
+                a loose coupling between applications and resources due to 
+                the manifold interaction possibilities. As a result,
                 at the time of writing typical API descriptions consist of a static mapping
                 from an application intent to a resource address,
                 method, request payload structure, response payload
@@ -1681,12 +1684,12 @@ a[href].internalDFN {
                 The <a>Interaction Model</a> of W3C WoT introduces an
                 intermediate abstraction that formalizes the mapping
                 from application intent to concrete protocol operations
-                and also narrows the possibilities how Interactions
+                and also narrows the possibilities how <a>Interaction Affordances</a>
                 can be modeled.
             </p>
             <p>
                 In addition to navigation affordances (i.e., Web links),
-                <a>Things</a> MAY only offer three other types of <a>Interaction Affordances</a>: Properties, Actions, and Events.
+                <a>Things</a> MAY only offer three other types of <a>Interaction Affordances</a>: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
                 While this narrow waist allows to decouple <a>Consumers</a> and <a>Things</a>,
                 these four types of <a>Interaction Affordances</a> are still able to model virtually all interaction possibilities found in IoT devices and services.
             </p>
@@ -1746,72 +1749,84 @@ a[href].internalDFN {
         </section>
         <section id="sec-hypermedia-controls">
             <h2>Hypermedia Controls</h2>
-            <p>Interaction Affordances showing the possible choices
-                to clients must originate from the Thing itself and are
-                shared during discovery or in-band during the
-                interaction with the Thing. This is opposed to
-                out-of-band interface descriptions that need to be
-                preinstalled or hardcoded into clients (e.g., RPC, WS-*
-                Web services, HTTP services with fixed
-                URI-method-response definitions).</p>
-            <p>To suggest how clients may interact with the Thing,
-                WoT makes use of hypermedia controls known from REST.
-                Besides the well-established Web links [[!RFC8288]], WoT
-                defines the concept of Web forms. They allow to adapt to
-                the diverse choices with which clients are faced in the
-                Internet of Things [[?FORMS]].</p>
+            <p>
+                On the Web, an affordance is the simultaneous presentation of information and controls,
+                such that the information becomes the affordance through which the user obtains choices.
+                For humans, the information is usally text or images describing or decorating a hyperlink.
+                The control is a Web link, which contains at least the URI of the target resource,
+                which can be dereferenced by the Web browser (i.e., the link can be followed).
+                But also machines can follow links in a meaningful way, when the Web link is further described by a relation type and a set of target attributes.
+                A hypermedia control is the machine-understandable serialization of <emph>how</emph> to activate an affordance.
+                Hypermedia controls usually originate from a Web server and are discovered in-band while a Web client is interacting with the server.
+                This way, Web servers can drive clients through Web applications dynamically,
+                by taking their current state and other factors such as authorization into account.
+                This is opposed to out-of-band interface descriptions that need to be preinstalled or hardcoded into clients
+                (e.g., RPC, WS-* Web services, HTTP services with fixed URI-method-response definitions).
+            </p>
+            <p>
+                W3C WoT makes use of two kinds of hypermedia controls:
+                Web links [[!RFC8288]] as the well-established control to navigate the Web,
+                and Web forms as a more powerful control to enable any kind of operation.
+                The same concept is used in the Constrained RESTful Application Language (CoRAL) defined by the IETF [[?CoRAL]].
+            </p>
             <section id="sec-hypermedia-links">
                 <h3>Links</h3>
                 <p>
-                    Web links enable clients to change the current
-                    context (e.g., the set of resource representations
-                    currently rendered in the Web browser) or to include
-                    further resources in the current context, depending
-                    on the relation between context and link target.
-                    Clients do so by <i>dereferencing</i> the target
-                    URI, that is, fetching the resource representation.
+                    Links enable <a>Consumers</a> (or Web clients in the broader sense) to change the current context
+                    (cf. the set of resource representations currently rendered in the Web browser)
+                    or to include additional resources into the current context,
+                    depending on the relation between context and link target.
+                    <a>Consumers</a> do so by <emph>dereferencing</emph> the target URI,
+                    that is, fetching the resource representation by following a link.
                 </p>
                 <p>
-                    A link is comprised of a link context, relation
-                    type, target, and optionally target attributes The
-                    underlying model for the relationships between
-                    resources on the Web (i.e., links) is defined in
-                    [[!RFC8288]]. link relation types are either
-                    IANA-registered tokens adhering to the ABNF
-                    <code style="white-space: nowrap;">LOALPHA *(
-                        LOALPHA / DIGIT / "." / "-" )</code>
-                    (e.g.,
-                    <code>stylesheet</code>
-                    ) or extension types in form of absolute URIs.
-                    [[!RFC8288]]
+                    W3C WoT follows the definitions of Web Linking [[!RFC8288]],
+                    where a link is comprised of:
+                    <ul>
+                        <li>a link context,</li>
+                        <li>a relation type,</li>
+                        <li>a link target, and</li>
+                        <li>optionally target attributes.</li>
+                    </ul>
                 </p>
-                <p>In the Web of Things, links are used for
-                    discovery and to express relations between Things
-                    (e.g., hierarchical or functional) and relations to
-                    other documents on the Web (e.g., manuals or
-                    alternative representations such as CAD models).</p>
+                <p>
+                    Link relation types are either IANA-registered tokens adhering to the ABNF
+                    <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code>
+                    (e.g., <code>stylesheet</code>) or extension types in the form of URIs [[!RFC3986]].
+                    Extension relation types MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion,
+                    character by character.
+                    Because of this, all-lowercase URIs SHOULD be used for extension relation types. [[!RFC8288]]
+                </p>
+                <p>
+                    In the Web of Things, links are used for discovery and to express relations between Things
+                    (e.g., hierarchical or functional)
+                    and relations to other documents on the Web
+                    (e.g., manuals or alternative representations such as CAD models).
+                </p>
             </section>
             <section id="sec-hypermedia-forms">
                 <h3>Forms</h3>
-                <p>Forms enable clients to perform interactions that
-                    go beyond dereferencing a URI such as manipulating
-                    resource state at the server. This usually requires
-                    more detailed information about the necessary
-                    request such as the method and header fields or
-                    protocol options. Forms can be seen as a request
-                    template, where the server prefilled part of the
-                    information according to its own interface and left
-                    parts blank to be filled by the client.</p>
-                <p>In the Web of Things, a form provides
-                    instructions to perform an operation on a resource
-                    and is comprised of:</p>
-                <ul>
-                    <li>a form context,</li>
-                    <li>a submission target,</li>
-                    <li>an operation type,</li>
-                    <li>a request method, and</li>
-                    <li>optionally form fields</li>
-                </ul>
+                <p>
+                    Forms enable <a>Consumers</a> (or Web clients in the broader sense) to perform operations that go beyond dereferencing a URI
+                    (e.g., manipulating state of a Thing).
+                    <a>Consumers</a> do so by <emph>filling out</emph> and <emph>submitting</emph> the form to its submission target.
+                    This usually requires more detailed information about the necessary request message than a link can provide
+                    (e.g., method, header fields, or other protocol options).
+                    Forms can be seen as a request template,
+                    where the provider prefilled parts of the information according to its own interface and state,
+                    and left parts blank to be filled by the <a>Consumers</a> (or Web client in general).
+                </p>
+                <p>
+                    W3C WoT defines forms as new hypermedia control in accordance with the definitions in CoRAL [[?CoRAL]].
+                    A form is comprised of:
+                    <ul>
+                        <li>a form context,</li>
+                        <li>an operation type,</li>
+                        <li>a request method,</li>
+                        <li>a submission target, and</li>
+                        <li>optionally form fields.</li>
+                    </ul>
+                </p>
                 <p>
                     A form can be viewed as a statement of "To perform a
                     <code>operation type</code>
@@ -1821,191 +1836,220 @@ a[href].internalDFN {
                     <code>request method</code>
                     request to
                     <code>submission target</code>
-                    " where form fields may further describe the
-                    required request.
+                    " where the optional form fields may further describe the required request.
                 </p>
-                <p>Form contexts and submission targets are both
+                <p>
+                    Form contexts and submission targets are both
                     Internationalized Resource Identifiers (IRIs)
                     [[!RFC3987]]. However, in the common case, they will
                     also be URIs [[!RFC3986]], because many protocols
                     (such as HTTP) do not support IRIs.</p>
-                <p>Form context and submission target may point to
+                <p>Form context and submission target MAY point to
                     the same resource or different resources, where the
                     submission target resource implements the operation
-                    for the context resource.</p>
+                    for the context.</p>
                 <p>The operation type identifies the semantics of
                     the operation. Operation types are denoted similar
                     to link relation types:</p>
                 <ul>
-                    <li><span class="rfc2119-assertion"
-                        id="arch-op-wellknown">Well-known
-                            operation types MUST have a name that
-                            follows the ABNF <code
-                                style="white-space: nowrap;">LOALPHA
-                                *( LOALPHA / DIGIT / "." / "-" )</code>.
-                    </span> <span class="rfc2119-assertion"
-                        id="arch-op-wellknown-compare">Names MUST
-                            be compared character by character in a
-                            case-insensitive fashion.</span> The well-known
-                        operation types for the Web of Things defined by
-                        this specification are given in the following
-                        table.</li>
-                    <li><span class="rfc2119-assertion"
-                        id="arch-op-extension">Extension
-                            operation types MAY be chosen by
-                            applications.</span> <span
-                        class="rfc2119-assertion"
-                        id="arch-op-extension-iri">Extension
-                            operation type names MUST be absolute URIs
-                            [[!RFC3986]] that uniquely identify the
-                            type.</span></li>
+                    <li>
+                        <span class="rfc2119-assertion" id="arch-op-wellknown">
+                            Well-known operation types MUST follow the ABNF
+                            <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code>.
+                        </span>
+                        <span class="rfc2119-assertion" id="arch-op-wellknown-compare">
+                            Well-known operation types MUST be compared character by character in a case-insensitive fashion.
+                        </span>
+                        The well-known operation types for the Web of Things defined by this specification are given in <a href="#table-operation-types">Table 1</a>.
+                    </li>
+                    <li>
+                        <span class="rfc2119-assertion" id="arch-op-extension">
+                            Extension operation types MAY be chosen by applications.
+                        </span>
+                        <span class="rfc2119-assertion" id="arch-op-extension-uri">
+                            Extension operation types MUST be URIs [[!RFC3986]] that uniquely identify the type.
+                        </span>
+                        <span class="rfc2119-assertion" id="arch-op-extension-comparison">
+                            Extension operation types MUST be compared as strings (after converting to URIs if serialised in a different format)
+                            character by character in a case-insensitive fashion.
+                        </span>
+                        <span class="rfc2119-assertion" id="arch-op-extension-lowercase">
+                            Because of this, all-lowercase URIs SHOULD be used for extension operation types.
+                        </span>
+                    </li>
                 </ul>
-                <figure id="table-operation-types">
-                <table class="def">
-                    <thead>
-                        <tr>
-                            <th>Operation Name</th>
-                            <th>Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>readproperty</td>
-                            <td>Identifies the read operation on
-                                Property Affordances to retrieve the
-                                corresponding data.</td>
-                        </tr>
-                        <tr>
-                            <td>writeproperty</td>
-                            <td>Identifies the write operation on
-                                Property Affordances to update the
-                                corresponding data.</td>
-                        </tr>
-                        <tr>
-                            <td>observeproperty</td>
-                            <td>Identifies the observe operation on
-                                Property Affordances to be notified with
-                                the new data when the Property was
-                                updated.</td>
-                        </tr>
-                        <tr>
-                            <td>unobserveproperty</td>
-                            <td>Identifies the unobserve
-                                operation on Property Affordances to stop
-                                the corresponding notifications.</td>
-                        </tr>
-                        <tr>
-                            <td>invokeaction</td>
-                            <td>Identifies the invoke operation on
-                                Action Affordances to perform the
-                                corresponding action.</td>
-                        </tr>
-                        <tr>
-                            <td>subscribeevent</td>
-                            <td>Identifies the subscribe operation
-                                on Event Affordances to be notified by
-                                the Thing when the event occurs.</td>
-                        </tr>
-                        <tr>
-                            <td>unsubscribeevent</td>
-                            <td>Identifies the unsubscribe
-                                operation on Event Affordances to stop
-                                the corresponding notifications.</td>
-                        </tr>
-                    </tbody>
-                </table>
-                    <figcaption>Well-known Operation Types for
-                        the Web of Things</figcaption>
-                </figure>
+                <p>
+                    The request method MUST identify one method of
+                    the standard set of the protocol identified by the
+                    submission target URI scheme.
+                </p>
+                <p>
+                    Form fields are optional and MAY further specify the
+                    expected request message for the given operation.
+                    Note that this is not limited to the payload, but may affect also protocol headers.
+                    Form fields MAY depend on the protocol used for the
+                    submission target (i.e., URI scheme). Examples are HTTP header fields,
+                    CoAP options, the protocol-independent Media Type(s)
+                    for the submission payload, or information about the
+                    expected response.
+                </p>
+                <div id="table-operation-types">
+                    <div style="text-align: center; font-style: italic;">Table 1 Well-known Operation Types for the Web of Things</div>
+                    <table class="def">
+                        <thead>
+                            <tr>
+                                <th>Operation Type</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>readproperty</td>
+                                <td>Identifies the read operation on
+                                    Property Affordances to retrieve the
+                                    corresponding data.</td>
+                            </tr>
+                            <tr>
+                                <td>writeproperty</td>
+                                <td>Identifies the write operation on
+                                    Property Affordances to update the
+                                    corresponding data.</td>
+                            </tr>
+                            <tr>
+                                <td>observeproperty</td>
+                                <td>Identifies the observe operation on
+                                    Property Affordances to be notified with
+                                    the new data when the Property was
+                                    updated.</td>
+                            </tr>
+                            <tr>
+                                <td>unobserveproperty</td>
+                                <td>Identifies the unobserve
+                                    operation on Property Affordances to stop
+                                    the corresponding notifications.</td>
+                            </tr>
+                            <tr>
+                                <td>invokeaction</td>
+                                <td>Identifies the invoke operation on
+                                    Action Affordances to perform the
+                                    corresponding action.</td>
+                            </tr>
+                            <tr>
+                                <td>subscribeevent</td>
+                                <td>Identifies the subscribe operation
+                                    on Event Affordances to be notified by
+                                    the Thing when the event occurs.</td>
+                            </tr>
+                            <tr>
+                                <td>unsubscribeevent</td>
+                                <td>Identifies the unsubscribe
+                                    operation on Event Affordances to stop
+                                    the corresponding notifications.</td>
+                            </tr>
+                            <tr>
+                                <td>readallproperties</td>
+                                <td>Identifies the readallproperties
+                                    operation on Things to retrieve the
+                                    data of all Properties in a single interaction.</td>
+                            </tr>
+                            <tr>
+                                <td>writeallproperties</td>
+                                <td>Identifies the writeallproperties
+                                    operation on Things to update the
+                                    data of all writable Properties in a single interaction.</td>
+                            </tr>
+                            <tr>
+                                <td>readmultipleproperties</td>
+                                <td>Identifies the readmultipleproperties
+                                    operation on Things to retrieve the
+                                    data of selected Properties in a single interaction.</td>
+                            </tr>
+                            <tr>
+                                <td>writemultipleproperties</td>
+                                <td>Identifies the writemultipleproperties
+                                    operation on Things to update the
+                                    data of selected writable Properties in a single interaction.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
                 <p class="ednote">As of this specification, the
-                    well-known operation types form a fixed set that
-                    results from the WoT interaction model. Other
+                    well-known operation types are a fixed set that
+                    results from the WoT <a>Interaction Model</a>. Other
                     specifications may define further well-known
                     operation types that are valid for their respective
                     document format or form serialization. Updates to
-                    this specification may set up an IANA registry in
+                    this specification or another specification may set up an IANA registry in
                     the future to enable extension and a more
                     generic Web form model that may be applied beyond
-                    WoT specifications.</p>
-                <p>The request method MUST identify one method of
-                    the standard set of the protocol identified by the
-                    submission target URI scheme.</p>
-                <p>Form fields may further specify the request
-                    expected by the server for the given operation. Form
-                    fields may depend on the protocol used for the
-                    submission target. Examples are HTTP header fields,
-                    CoAP options, the protocol-independent Media Type(s)
-                    for the submission payload, or information about the
-                    expected response.</p>
+                    WoT specifications.
+                </p>
             </section>
         </section>
         <section id="sec-protocol-bindings">
             <h2>Protocol Bindings</h2>
             <p>
-                A Protocol Binding is the mapping from an Interaction Affordance to concrete messages of a specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]].
-                The Protocol Bindings follow the Uniform Interface constraint of REST [[?REST]] to support interoperability
-                and are serialized as hypermedia controls to be self-descriptive.
+                A Protocol Binding is the mapping from an <a>Interaction Affordance</a> to concrete messages of a specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]].
+                It informs the <a>Consumer</a> <emph>how</emph> to activate the <a>Interaction Affordance</a> through a network-facing interface.
+                The <a>Protocol Bindings</a> follow the Uniform Interface constraint of REST [[?REST]] to support interoperability.
+            </p>
+            <p>
+                In the door example given in <a href="#sec-affordances"></a>, the <a>Protocol Binding</a> corresponds to the door handle at the level of knob vs lever,
+                which suggests <emph>how</emph> the door can be opened.
             </p>
             <section>
                 <h3>Hypermedia-driven</h3>
                 <p>
-                    <span class="rfc2119-assertion" id="arch-hypermedia">Interaction
-                        Affordances MUST use hypermedia controls (see <a
-                        href="#sec-hypermedia-controls"></a>) to
-                        describe their usage.
-                    </span> <span class="rfc2119-assertion"
-                        id="arch-hypermedia-origin">The
-                        hypermedia controls MUST originate from the
-                        Thing providing the corresponding Interaction
-                        Affordance.</span> This enables a loose coupling
-                    between Things and clients, allowing for an
-                    independent lifecycle and evolution. <span
-                        class="rfc2119-assertion"
-                        id="arch-hypermedia-caching">The
-                        hypermedia controls MAY be cached outside the
-                        Thing and used for offline processing if
-                        corresponding caching metadata is available to
-                        determine the freshness.</span>
+                    <span class="rfc2119-assertion" id="arch-hypermedia">
+                        Interaction Affordances MUST contain one ore more Protocol Bindings, which MUST be serialized as hypermedia controls (see <a
+                        href="#sec-hypermedia-controls"></a>) to to be self-descriptive on how to activate the Interaction Affordance.
+                    </span>
+                    <span class="rfc2119-assertion" id="arch-hypermedia-origin">
+                        The hypermedia controls MUST originate from the authority managing the Thing providing the corresponding Interaction Affordance.
+                    </span>
+                    The authority can be the <a>Thing</a> itself, serializing the <a>WoT Thing Description</a> at runtime based on its current state including network parameters such as its IP address,
+                    or an external entity that has full and fresh knowledge of the <a>Thing</a> including its network parameters and software stack.
+                    This enables a loose coupling between Things and clients, allowing for an independent lifecycle and evolution.
+                    <span class="rfc2119-assertion" id="arch-hypermedia-caching">
+                        The hypermedia controls MAY be cached outside the Thing and used for offline processing if corresponding caching metadata is available to determine the freshness.
+                    </span>
                 </p>
             </section>
             <section id="sec-arch-URIs">
                 <h3>URIs</h3>
                 <p>
-                    <span class="rfc2119-assertion" id="arch-uri-scheme">Eligible
-                        protocols for the Web of Things MUST have an
-                        associated URI scheme that is registered with IANA
-                        [[!RFC4395]].</span> Hypermedia controls rely on URIs to
-                    identify target resources and submission targets.
-                    Thereby, the URI scheme (the first component up to ":")
-                    identifies the communication protocol to be used for
-                    interaction with the Thing. The Web of Things refers to
-                    these protocols as <a>transfer protocols</a>.
+                    <span class="rfc2119-assertion" id="arch-uri-scheme">
+                        Eligible protocols for W3C WoT MUST have an associated URI scheme that is registered with IANA [[!RFC4395]].
+                    </span>
+                    Hypermedia controls rely on URIs to identify link and submission targets.
+                    Thereby, the URI scheme (the first component up to ":") identifies the communication protocol to be used for interaction with the Thing.
+                    W3C WoT refers to these protocols as <a>transfer protocols</a>.
                 </p>
             </section>
             <section id="sec-standard-method">
                 <h3>Standard Set of Methods</h3>
                 <p>
                     <span class="rfc2119-assertion" id="arch-methods">Eligible
-                        protocols for the Web of Things MUST be based on a
-                        standard set of methods that can be shared a priori.</span>
+                        protocols for W3C WoT MUST be based on a
+                        standard set of methods that is known a priori.</span>
                     The standard set of methods makes messages
                     self-descriptive to enable intermediate processing of
                     interactions, for instance by proxies or to translate
                     between Protocol Bindings [[?REST]]. Furthermore, it
-                    allows clients to have application-agnostic protocol
-                    stack, avoiding Thing-specific code or plugins.
+                    allows <a>Consumers</a> to have re-usable protocol
+                    stacks of common transfer protocols such as HTTP, CoAP, or MQTT,
+                    avoiding Thing-specific code or plugins.
                 </p>
             </section>
             <section id="media-types">
                 <h3>Media Types</h3>
                 <p>
                     <span class="rfc2119-assertion" id="arch-media-type">All
-                        data (a.k.a. content) exchanged within Interaction
-                        Affordances MUST be identified by a Media Type
-                        [[!RFC6838]].</span> Media Types are IANA-managed labels to
-                    identify representation formats, for instance
+                        data (a.k.a. content) exchanged when activating Interaction Affordances MUST be identified by a Media Type
+                        [[!RFC6838]] within the Protocol Binding.</span>
+                    Media Types are IANA-managed labels to identify representation formats, for instance
                     <code>application/json</code>
-                    for JSON [[!RFC7159]] or
+                    for JSON [[!RFC8259]] or
                     <code>application/cbor</code>
                     for CBOR [[!RFC7049]].
                 </p>

--- a/index.html
+++ b/index.html
@@ -1704,7 +1704,7 @@ a[href].internalDFN {
                     that MUST be retrievable (read) and optionally MAY be updated (write).
                     Things MAY choose to make Properties observable by pushing the new state after a change
                     (cf. Observing Resources [[?RFC7641]]).
-                    Write-only state SHOULD be exposed through an Action.
+                    Write-only state should be updated through an Action.
                 </p>
                 <p>
                     Properties MAY contain one data schema if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type).

--- a/index.html
+++ b/index.html
@@ -1823,8 +1823,8 @@ a[href].internalDFN {
                     <ul>
                         <li>a form context,</li>
                         <li>an operation type,</li>
-                        <li>a request method,</li>
-                        <li>a submission target, and</li>
+                        <li>a submission target,</li>
+                        <li>a request method, and</li>
                         <li>optionally form fields.</li>
                     </ul>
                 </p>
@@ -1890,7 +1890,7 @@ a[href].internalDFN {
                     Note that this is not limited to the payload, but may affect also protocol headers.
                     Form fields MAY depend on the protocol used for the
                     submission target (i.e., URI scheme). Examples are HTTP header fields,
-                    CoAP options, the protocol-independent Media Type(s)
+                    CoAP options, the protocol-independent Media Type including parameters (i.e., full content type)
                     for the submission payload, or information about the
                     expected response.
                 </p>

--- a/index.html
+++ b/index.html
@@ -357,14 +357,14 @@ a[href].internalDFN {
             <dd>A re-usable collection of blueprints for the
                 communication with different IoT platforms. The
                 blueprints includes the required vocabulary for the
-                Thing Description to map Interactions to
+                WoT Thing Description to map Interactions to
                 platform-specific messages as well as implementation
                 notes for the required protocol stacks or dedicated
                 communication drivers.</dd>
             <dt>
                 <dfn>to consume a Thing</dfn>
             </dt>
-            <dd>To process a Thing Description and from it create a Consumed
+            <dd>To process a WoT Thing Description and from it create a Consumed
                 Thing software abstraction as interface for the application in the local
                 runtime environment.</dd>
             <dt>
@@ -451,7 +451,7 @@ a[href].internalDFN {
                 <dfn>Intermediary</dfn>
             </dt>
             <dd>An entity between Consumers and Things that can proxy, augment, or compose things
-                and republish a Thing Description that points to the WoT Interface on the Intermediary instead of the original Thing.
+                and republish a WoT Thing Description that points to the WoT Interface on the Intermediary instead of the original Thing.
                 For Consumers, an Intermediary may be indistinguishable from a Thing, following the Layered System constraint of REST.</dd>
             <dt>
                 <dfn>IoT platform</dfn>
@@ -495,7 +495,7 @@ a[href].internalDFN {
             <dt>
                 <dfn>TD</dfn>
             </dt>
-            <dd>Short for Thing Description.</dd>
+            <dd>Short for WoT Thing Description.</dd>
             <dt>
                 <dfn>TD Vocabulary</dfn>
             </dt>
@@ -532,13 +532,13 @@ a[href].internalDFN {
                 <dfn>WoT Interface</dfn>
             </dt>
             <dd>The network-facing interface of a Thing
-                that is described by a Thing Description.</dd>
+                that is described by a WoT Thing Description.</dd>
             <dt>
                 <dfn>WoT Runtime</dfn>
             </dt>
             <dd>A runtime system that maintains an execution
                 environment for applications, and is able to expose and/or
-                consume Things, to process Thing Descriptions, to maintain private security
+                consume Things, to process WoT Thing Descriptions, to maintain private security
                 metadata, and to interface with Protocol Binding implementations.
                 A WoT Runtime may have a custom API or use the optional WoT Scripting API.</dd>
             <dt>
@@ -556,10 +556,10 @@ a[href].internalDFN {
             <dt>
                 <dfn>WoT Thing Description</dfn> or <dfn>Thing Description</dfn>
             </dt>
-            <dd>Structured data describing a Thing. A Thing Description comprises
+            <dd>Structured data describing a Thing. A WoT Thing Description comprises
                 general metadata, domain-specific metadata, Interaction Affordances
                 (which include the supported Protocol Bindings), and links to related Things.
-                The WoT Thing Description is the central building block of W3C WoT.</dd>
+                The WoT Thing Description format is the central building block of W3C WoT.</dd>
         </dl>
     </section>
 
@@ -1506,12 +1506,12 @@ a[href].internalDFN {
                 the Web of Things (WoT) builds on top of the concept of Web Things &ndash; usually simply called <a>Things</a> &ndash; that can be used by so-called <a>Consumers</a>.
                 A Thing is the abstraction of a physical or virtual entity (e.g., a device or a room, resp.)
                 and is described by standardized metadata.
-                In W3C WoT, the description metadata MUST be a WoT Thing Description [[!wot-thing-description]].
-                <a>Consumers</a> MUST be able to process the WoT Thing Description format, which is based on JSON [[!rfc8259]].
-                A Thing Description (TD) is instance-specific (i.e., describes an individual Thing, not types of Things)
+                In W3C WoT, the description metadata MUST be a WoT Thing Description (TD) [[!wot-thing-description]].
+                <a>Consumers</a> MUST be able to process the <a>WoT Thing Description</a> format, which is based on JSON [[!rfc8259]].
+                A <a>TD</a> is instance-specific (i.e., describes an individual Thing, not types of Things)
                 and is the default Web representation of a Thing.
                 There MAY be other Web representations of a Thing such as an HTML-based user interface or simply an image of the physical entity.
-                However, the WoT Thing Description is a standardized, machine-understandable representation format
+                However, the <a>WoT Thing Description</a> is a standardized, machine-understandable representation format
                 that allows <a>Consumers</a> to discover and interpret the capabilities of a Thing (through semantic annotations)
                 and to adapt to different implementations (e.g., different protocols or data structures) when interacting with a Thing,
                 thereby enabling interoperability across different <a>IoT platforms</a>, i.e., different ecosystems and standards.
@@ -1521,9 +1521,9 @@ a[href].internalDFN {
             </p>
             <p>
                 A Thing can also abstract a virtual entity, which is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
-                One option for the composition is to provide a single, consolidated <a>Thing Description</a> that contains the superset of capabilities for the virtual entity.
-                In cases where the composition is rather complex, its <a>Thing Description</a> may <emph>link</emph> to hierarchical sub-Things within the composition.
-                The main <a>Thing Description</a> acts as entry point and only contain general metadata and potentially overarching capabilities.
+                One option for the composition is to provide a single, consolidated <a>WoT Thing Description</a> that contains the superset of capabilities for the virtual entity.
+                In cases where the composition is rather complex, its <a>TD</a> may <emph>link</emph> to hierarchical sub-Things within the composition.
+                The main <a>TD</a> acts as entry point and only contain general metadata and potentially overarching capabilities.
                 This allows grouping of certain aspects of more complex Things.
             </p>
             <p>
@@ -1532,8 +1532,7 @@ a[href].internalDFN {
                 Other resources related to a Thing can be manuals, catalogs for spare parts, CAD files, a graphical UI, or any other document on the Web.
                 Overall, Web linking among Things makes the Web of Things browsable.
                 This can be further facilitated by providing Thing directories that manage an index of available Things, usually by caching their TD representation.
-                In summary, <a>Thing Descriptions</a> MAY link to other <a>Things</a> and other resources on the Web to form a Web of Things.
-                Links in <a>Thing Descriptions</a> MUST have a relation type.
+                In summary, <a>WoT Thing Descriptions</a> MAY link to other <a>Things</a> and other resources on the Web to form a Web of Things.
             </p>
             <p class="ednote" title="TODO">
                 Figure to illustrate linked Things.
@@ -1546,13 +1545,13 @@ a[href].internalDFN {
             <p>
                 A typical deployment challenge is that local networks are not reachable from the Internet, usually because of IPv4 NATs or firewalls.
                 To remedy this situation, W3C WoT allows for <a>Intermediaries</a> between <a>Things</a> and <a>Consumers</a>.
-                <a>Intermediaries</a> can act as proxies for <a>Things</a>, where the <a>Intermediary</a> has a <a>Thing Description</a> similar to the original <a>Thing</a>,
+                <a>Intermediaries</a> can act as proxies for <a>Things</a>, where the <a>Intermediary</a> has a <a>WoT Thing Description</a> similar to the original <a>Thing</a>,
                 but which points to the <a>WoT Interface</a> provided by the <a>Intermediary</a>.
                 <a>Intermediaries</a> may also augment existing <a>Things</a> with additional capabilities or compose a new <a>Thing</a> out of multiple available <a>Things</a>,
                 thereby forming a virtual entity.
-                To <a>Consumers</a>, <a>Intermediaries</a> look like <a>Things</a>, as they possess <a>Thing Descriptions</a> and provide a <a>WoT Interface</a>,
+                To <a>Consumers</a>, <a>Intermediaries</a> look like <a>Things</a>, as they possess <a>WoT Thing Descriptions</a> and provide a <a>WoT Interface</a>,
                 and hence might be indistinguishable from <a>Things</a> in a layered system architecture like the Web [[?REST]].
-                An identifier in the <a>Thing Description</a> MUST allow for the correlation of multiple <a>Thing Descriptions</a> representing the same original <a>Thing</a> or ultimately unique physical entity.
+                An identifier in the <a>WoT Thing Description</a> MUST allow for the correlation of multiple <a>TDs</a> representing the same original <a>Thing</a> or ultimately unique physical entity.
             </p>
             <p class="ednote" title="TODO">
                 Figure to illustrate intermediaries.
@@ -1579,7 +1578,7 @@ a[href].internalDFN {
         <section>
             <h2>Affordances</h2>
             <p>
-                A central aspect in W3C WoT is the provision of machine-understandable metadata (i.e., <a>Thing Descriptions</a>).
+                A central aspect in W3C WoT is the provision of machine-understandable metadata (i.e., <a>WoT Thing Descriptions</a>).
                 Ideally, such metadata is self-descriptive, so that <a>Consumers</a> are able to identify
                 <emph>what</emph> capabilities a <a>Thing</a> provides and <emph>how</emph> to use the provided capabilities.
                 A key to this self-descriptiveness lies in the concept of affordances.

--- a/index.html
+++ b/index.html
@@ -1507,7 +1507,7 @@ a[href].internalDFN {
         </p>
         <section id="sec-architecture-overview">
             <h2>Overview</h2>
-                A <a>Thing</a> is the abstraction of a physical or virtual entity (e.g., a device or a room, resp.) and is described by standardized metadata.
+                A <a>Thing</a> is the abstraction of a physical or virtual entity (e.g., a device or a room) and is described by standardized metadata.
                 In W3C WoT, the description metadata MUST be a WoT Thing Description (TD) [[!wot-thing-description]].
                 <a>Consumers</a> MUST be able to process the <a>WoT Thing Description</a> format, which is based on JSON [[!RFC8259]].
                 The format can be processed either through classic JSON libraries or a JSON-LD processor, as the underlying information model is graph-based and its serialization compatible with JSON-LD 1.1 [[?json-ld-syntax]].

--- a/index.html
+++ b/index.html
@@ -1513,8 +1513,10 @@ a[href].internalDFN {
                 The format can be processed either through classic JSON libraries or a JSON-LD processor, as the underlying information model is graph-based and its serialization compatible with JSON-LD 1.1 [[?json-ld-syntax]].
                 A <a>TD</a> is instance-specific (i.e., describes an individual Thing, not types of Things)
                 and is the default Web representation of a <a>Thing</a>.
-                There MAY be other Web representations of a <a>Thing</a> such as an HTML-based user interface or simply an image of the physical entity.
-                However, the <a>WoT Thing Description</a> is a standardized, machine-understandable representation format
+                There MAY be other representations of a <a>Thing</a> such as an HTML-based user interface, simply an image of the physical entity,
+                or even non-Web representations in closed systems;
+                to be a <a>Thing</a>, however, one <a>TD</a> representation MUST be available.
+                The <a>WoT Thing Description</a> is a standardized, machine-understandable representation format
                 that allows <a>Consumers</a> to discover and interpret the capabilities of a Thing (through semantic annotations)
                 and to adapt to different implementations (e.g., different protocols or data structures) when interacting with a Thing,
                 thereby enabling interoperability across different <a>IoT platforms</a>, i.e., different ecosystems and standards.
@@ -1523,8 +1525,8 @@ a[href].internalDFN {
                 Simple figure to illustrate Consumer--Thing interaction.
             </p>
             <p>
-                A <a>Thing</a> can also be the abstraction of a virtual entity,
-                which is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
+                A <a>Thing</a> can also be the abstraction of a virtual entity.
+                A virtual entity is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
                 One option for the composition is to provide a single, consolidated <a>WoT Thing Description</a> that contains the superset of capabilities for the virtual entity.
                 In cases where the composition is rather complex, its <a>TD</a> may <emph>link</emph> to hierarchical sub-Things within the composition.
                 The main <a>TD</a> acts as entry point and only contain general metadata and potentially overarching capabilities.
@@ -1534,7 +1536,7 @@ a[href].internalDFN {
                 Linking does not only apply to hierarchical Things, but relations between Things and other resources in general.
                 Link relation types express how Things relate, for instance, a switch controlling a light or a room monitored by a motion sensor.
                 Other resources related to a Thing can be manuals, catalogs for spare parts, CAD files, a graphical UI, or any other document on the Web.
-                Overall, Web linking among Things makes the Web of Things browsable.
+                Overall, Web linking among Things makes the Web of Things browsable, for both humans and machines.
                 This can be further facilitated by providing Thing directories that manage an index of available Things, usually by caching their TD representation.
                 In summary, <a>WoT Thing Descriptions</a> MAY link to other <a>Things</a> and other resources on the Web to form a Web of Things.
             </p>
@@ -1543,7 +1545,7 @@ a[href].internalDFN {
             </p>
             <p>
                 Things must be hosted on networked system components with a software stack to realize interaction through a network-facing interface, the <a>WoT Interface</a> of a <a>Thing</a>.
-                One example of this is an HTTP server running on an embedded device with sensors and actutors interfacing the physical entity behind the Thing abstraction.
+                One example of this is an HTTP server running on an embedded device with sensors and actuators interfacing the physical entity behind the Thing abstraction.
                 However, W3C WoT does not mandate where <a>Things</a> are hosted; it can be on the IoT device directly, an <a>Edge device</a> such as a gateway box, or the cloud.
             </p>
             <p>
@@ -1618,6 +1620,7 @@ a[href].internalDFN {
                 hyperlink (e.g., via a link relation type and link
                 target attributes) suggesting Web clients how to navigate
                 and possibly how to act on the linked resource.
+                Hence, links provide navigation affordances.
             </p>
             <p>
                 Drawn from this hypermedia principle,
@@ -1728,7 +1731,7 @@ a[href].internalDFN {
                     Examples of Actions are changing multiple Properties simultaneously,
                     changing Properties over time such as fading the brightness of a light (dimming)
                     or with a process that shall not be disclosed such as a proprietary control loop algorithm,
-                    or invoking a long-lasting process such as priting a document.</p>
+                    or invoking a long-lasting process such as printing a document.</p>
             </section>
             <section>
                 <h3>Events</h3>
@@ -1753,7 +1756,7 @@ a[href].internalDFN {
             <p>
                 On the Web, an affordance is the simultaneous presentation of information and controls,
                 such that the information becomes the affordance through which the user obtains choices.
-                For humans, the information is usally text or images describing or decorating a hyperlink.
+                For humans, the information is usually text or images describing or decorating a hyperlink.
                 The control is a Web link, which contains at least the URI of the target resource,
                 which can be dereferenced by the Web browser (i.e., the link can be followed).
                 But also machines can follow links in a meaningful way, when the Web link is further described by a relation type and a set of target attributes.
@@ -1791,7 +1794,7 @@ a[href].internalDFN {
                     </ul>
                 </p>
                 <p>
-                    Link relation types are either IANA-registered tokens adhering to the ABNF
+                    Link relation types are either IANA-registered tokens [[IANA-RELATIONS]] adhering to the ABNF [[!RFC5234]]
                     <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code>
                     (e.g., <code>stylesheet</code>) or extension types in the form of URIs [[!RFC3986]].
                     Extension relation types MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion,

--- a/index.html
+++ b/index.html
@@ -1523,7 +1523,8 @@ a[href].internalDFN {
                 Simple figure to illustrate Consumer--Thing interaction.
             </p>
             <p>
-                A Thing can also abstract a virtual entity, which is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
+                A <a>Thing</a> can also be the abstraction of a virtual entity,
+                which is the composition of one or more Things (e.g., a room consisting of several sensors and actuators).
                 One option for the composition is to provide a single, consolidated <a>WoT Thing Description</a> that contains the superset of capabilities for the virtual entity.
                 In cases where the composition is rather complex, its <a>TD</a> may <emph>link</emph> to hierarchical sub-Things within the composition.
                 The main <a>TD</a> acts as entry point and only contain general metadata and potentially overarching capabilities.
@@ -2037,8 +2038,8 @@ a[href].internalDFN {
                     interactions, for instance by proxies or to translate
                     between Protocol Bindings [[?REST]]. Furthermore, it
                     allows <a>Consumers</a> to have re-usable protocol
-                    stacks of common transfer protocols such as HTTP, CoAP, or MQTT,
-                    avoiding Thing-specific code or plugins.
+                    stacks of common <a>transfer protocols</a> such as HTTP, CoAP, or MQTT,
+                    avoiding Thing-specific code or plugins for <a>Consumers</a>.
                 </p>
             </section>
             <section id="media-types">


### PR DESCRIPTION
This is work in progress.

Section 6.1 already contains new text to define Things and Consumers independent from client/server roles.

The change also includes regrouping to reflect clarifications around Interaction Affordances, Hypermedia Controls, and Protocol Bindings as discussed during the joint IETF workshop.

The section for system components introducing Servients is now 6.7 (for @takuki and @mryuichi )