### PR TITLE
emphasize 'Describe, don't prescribe' in Abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@ a[href].internalDFN {
         </ul>
         </p>
         <p>Overall, the goal is to preserve and support existing
-            security mechanisms and properties. In general, W3C WoT is
+            IoT standards and solutions. In general, W3C WoT is
             designed to describe what exists rather than to prescribe
             what to implement.</p>
 


### PR DESCRIPTION
In last paragraph of Abstract:
> Overall, the goal is to preserve and support existing security mechanisms and properties. In general, W3C WoT is designed to describe what exists rather than to prescribe what to implement.

"Describe, don't prescribe" is a principle of WoT, not restricted to security.
To emphasize this, this PR updates a first sentence of the paragraph.
