### PR TITLE
Editorial fix for Issue #204

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ a[href].internalDFN {
             set of requirements that were derived from use cases for
             multiple application domains. The architecture can be mapped
             onto a variety of concrete deployment scenarios, several
-            examples of which are given.</p>
+            examples patterns of which are given.</p>
         <p>The document is focused on the scope of W3C WoT
             standardization, which consists of three initial building
             blocks. These are described by additional WoT

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ a[href].internalDFN {
             set of requirements that were derived from use cases for
             multiple application domains. The architecture can be mapped
             onto a variety of concrete deployment scenarios, several
-            examples patterns of which are given.</p>
+            example patterns of which are given.</p>
         <p>The document is focused on the scope of W3C WoT
             standardization, which consists of three initial building
             blocks. These are described by additional WoT


### PR DESCRIPTION
In the abstract there is a mention to "concrete deployment scenarios" as follows.

> The architecture can be mapped onto a variety of concrete deployment scenarios, several examples of which are given.

The above was changed to:

> The architecture can be mapped onto a variety of concrete deployment scenarios, several example **patterns** of which are given.
