### PR TITLE
(Editorial) "WoT Network Components" to "devices" (Issue #205) 

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,8 +216,7 @@ a[href].internalDFN {
             The optional <a>WoT Scripting API</a> enables implementation of
             the application logic of a Thing using a standardized
             contract for JavaScript. This simplifies IoT application
-            development and enables portability across vendors and WoT
-            network components.
+            development and enables portability across vendors and devices.
         </p>
 
         <p>Other non-normative architectural blocks and conditions


### PR DESCRIPTION
In the abstract, there is a phrase "WoT network components".

This was changed to "devices".