### PR TITLE
Moved the historical information to the acknowledgement (Issue #206)

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,20 +258,11 @@ a[href].internalDFN {
     <section id="introduction">
         <h1>Introduction</h1>
         <p>
-            The "Web of Things" (WoT) started as an academic initiative
-            in the form of publications and, starting in 2010, a yearly
-            <a href="https://webofthings.org/events/">International
-                Workshop on the Web of Things</a> . Its goal is to improve
-            interoperability as well as usability in the Internet of
-            Things (IoT). With the increasing role of IoT services using
-            other web standards in commercial and industrial
-            applications, the W3C chartered an <a
-                href="https://www.w3.org/WoT/IG/">Interest Group</a> in
-            2015 to identify technological building blocks for
-            Recommendation Track standardization. With the WoT <a
-                href="https://www.w3.org/WoT/WG/">Working Group</a>
-            chartered end of 2016, the first set of WoT building blocks
-            has now being standardized:
+            The goals of the "Web of Things" (WoT) are to improve the interoperability 
+            and usability of the Internet of Things (IoT). Through a collaboration 
+            involving many stakeholders over the past years, several building 
+            blocks have been identified that address these challenges.
+            The first set of WoT building blocks are now being standardized:
         </p>
         <ul>
             <li>the <em>Web of Things (WoT)
@@ -3482,9 +3473,14 @@ a[href].internalDFN {
     <section class="appendix-acknowledgements">
         <h2>Acknowledgments</h2>
         <p>Special thanks to all active Participants of the W3C Web
-            of Things Interest Group and Working Group for their
+            of Things Interest Group (WoT IG) and Working Group (WoT WG) for their
             technical input and suggestions that led to improvements to
             this document.</p>
+        <p>The WoT WG also would like to appreciate the pioneering efforts 
+           regarding the concept of "Web of Things" that started as an academic 
+           initiative in the form of publications such as [TBD] and, starting 
+           in 2010, a yearly <a href="https://webofthings.org/events/">
+           International Workshop on the Web of Things</a>.</p>
     </section>
 
     <section class="appendix-change-history">


### PR DESCRIPTION
It should cite a paper that pioneered the concept of WoT.

Here is a [link](https://cdn.staticaly.com/gh/w3c/wot-architecture/07e61645229de96b7e1a89845d37b136f4a67e1e/index.html?env=dev#acknowledgments) to the new Acknowledgement section.

@mkovatsc , please make an advice.