### PR TITLE
Mark up all assertions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1525,14 +1525,22 @@ a[href].internalDFN {
             <h2>Overview</h2>
             <p>
                 A <a>Thing</a> is the abstraction of a physical or virtual entity (e.g., a device or a room) and is described by standardized metadata.
-                In W3C WoT, the description metadata MUST be a WoT Thing Description (TD) [[!wot-thing-description]].
-                <a>Consumers</a> MUST be able to process the <a>WoT Thing Description</a> format, which is based on JSON [[!RFC8259]].
+                <span class="rfc2119-assertion" id="arch-td-metadata">
+                  In W3C WoT, the description metadata MUST be a WoT Thing Description (TD) [[!wot-thing-description]].
+                </span>
+                <span class="rfc2119-assertion" id="arch-td-consumers-process">
+                  <a>Consumers</a> MUST be able to process the <a>WoT Thing Description</a> format, which is based on JSON [[!RFC8259]].
+                </span>
                 The format can be processed either through classic JSON libraries or a JSON-LD processor, as the underlying information model is graph-based and its serialization compatible with JSON-LD 1.1 [[?json-ld-syntax]].
                 A <a>TD</a> is instance-specific (i.e., describes an individual Thing, not types of Things)
                 and is the default Web representation of a <a>Thing</a>.
+                <span class="rfc2119-assertion" id="arch-other-thing-representations">
                 There MAY be other representations of a <a>Thing</a> such as an HTML-based user interface, simply an image of the physical entity,
-                or even non-Web representations in closed systems;
-                to be a <a>Thing</a>, however, one <a>TD</a> representation MUST be available.
+                or even non-Web representations in closed systems.
+                </span>
+                <span class="rfc2119-assertion" id="arch-td-mandatory">
+                To be a <a>Thing</a>, however, one <a>TD</a> representation MUST be available.
+                </span>
                 The <a>WoT Thing Description</a> is a standardized, machine-understandable representation format
                 that allows <a>Consumers</a> to discover and interpret the capabilities of a Thing (through semantic annotations)
                 and to adapt to different implementations (e.g., different protocols or data structures) when interacting with a Thing,
@@ -1557,7 +1565,10 @@ a[href].internalDFN {
                 Other resources related to a Thing can be manuals, catalogs for spare parts, CAD files, a graphical UI, or any other document on the Web.
                 Overall, Web linking among Things makes the Web of Things browsable, for both humans and machines.
                 This can be further facilitated by providing Thing directories that manage an index of available Things, usually by caching their TD representation.
-                In summary, <a>WoT Thing Descriptions</a> MAY link to other <a>Things</a> and other resources on the Web to form a Web of Things.
+                In summary, 
+                <span class="rfc2119-assertion" id="arch-td-linking"><a>WoT Thing Descriptions</a> 
+                MAY link to other <a>Things</a> and other resources on the Web to form a Web of Things.
+                </span>
             </p>
             <figure id="linked-things">
                 <img src="images/architecture/linked-things.png"
@@ -1578,7 +1589,9 @@ a[href].internalDFN {
                 thereby forming a virtual entity.
                 To <a>Consumers</a>, <a>Intermediaries</a> look like <a>Things</a>, as they possess <a>WoT Thing Descriptions</a> and provide a <a>WoT Interface</a>,
                 and hence might be indistinguishable from <a>Things</a> in a layered system architecture like the Web [[?REST]].
+                <span class="rfc2119-assertion" id="arch-id-correlation">
                 An identifier in the <a>WoT Thing Description</a> MUST allow for the correlation of multiple <a>TDs</a> representing the same original <a>Thing</a> or ultimately unique physical entity.
+                </span>
             </p>
             <figure id="intermediary">
                 <img src="images/architecture/intermediary.png"
@@ -1589,9 +1602,11 @@ a[href].internalDFN {
                 Another remedy for unreachable local networks would be to bind the <a>WoT Interface</a> to a protocol that establishes the connection from the <a>Thing</a> within the local network to a publicly reachable <a>Consumer</a>.
             </p>
             <p>
-                Things MAY be bundled together with a Consumer to enable Thing-to-Thing interaction.
+                <span class="rfc2119-assertion" id="arch-thing-bundling">Things 
+                MAY be bundled together with a Consumer to enable Thing-to-Thing interaction.</span>
                 Usually, the Consumer behavior is embedded in the software also implementing the behavior of the Thing.
-                The configuration of the Consumer behavior MAY be exposed through the Thing.
+                <span class="rfc2119-assertion" id="arch-consumer-configuration">The 
+                configuration of the Consumer behavior MAY be exposed through the Thing.</span>
             </p>
             <p>
                 The concepts of W3C WoT are applicable to all levels relevant for IoT applications: the device level, edge level, and cloud level.
@@ -1703,23 +1718,35 @@ a[href].internalDFN {
                 can be modeled.
             </p>
             <p>
-                In addition to navigation affordances (i.e., Web links),
-                <a>Things</a> MAY offer three other types of <a>Interaction Affordances</a> defined by this document: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
+                <span class="rfc2119-assertion" id="arch-affordances">In 
+                addition to navigation affordances (i.e., Web links),
+                <a>Things</a> MAY offer three other types of <a>Interaction Affordances</a> 
+                defined by this document: <a>Properties</a>, <a>Actions</a>, and <a>Events</a>.
+                </span>
                 While this narrow waist allows to decouple <a>Consumers</a> and <a>Things</a>,
                 these four types of <a>Interaction Affordances</a> are still able to model virtually all interaction possibilities found in IoT devices and services.
             </p>
             <section>
                 <h3>Properties</h3>
                 <p>
-                    A Property is an Interaction Affordance that exposes state of the Thing
-                    that MUST be retrievable (read) and optionally MAY be updated (write).
+                    A Property is an Interaction Affordance that exposes state of the Thing.
+                    <span class="rfc2119-assertion" id="arch-property-readable">
+                    The state exposed by a Property MUST be retrievable (readable).
+                    </span>
+                    <span class="rfc2119-assertion" id="arch-property-writable">
+                    Optionally, the state exposed by a Property MAY be updated (writeable).
+                    </span>
+                    <span class="rfc2119-assertion" id="arch-property-observable">
                     Things MAY choose to make Properties observable by pushing the new state after a change
                     (cf. Observing Resources [[?RFC7641]]).
+                    </span>
                     Write-only state should be updated through an Action.
                 </p>
                 <p>
+                    <span class="rfc2119-assertion" id="arch-property-dataschema">
                     Properties MAY contain one data schema for the exposed state,
                     if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type).
+                    </span>
                 </p>
                 <p>
                     Examples of Properties are sensor values (read-only), stateful actuators (read-write),
@@ -1729,14 +1756,21 @@ a[href].internalDFN {
             <section>
                 <h3>Actions</h3>
                 <p>
-                    An Action is an Interaction Affordance that allows to invoke a function of the Thing,
-                    which MAY manipulate state that is not directly exposed (cf. Properties),
+                    An Action is an Interaction Affordance that allows to invoke a function of the Thing.
+                    <span class="rfc2119-assertion" id="arch-action-functions">
+                    An Action MAY manipulate state that is not directly exposed (cf. Properties),
                     manipulate multiple Properties at a time, or manipulate Properties based on internal logic (e.g., toggle).
-                    Invoking an Action MAY also trigger a process on the Thing that manipulates state (including physical state through actuators) over time.
+                    </span>
+                    <span class="rfc2119-assertion" id="arch-action-process">
+                    Invoking an Action MAY also trigger a process on the Thing that manipulates state 
+                    (including physical state through actuators) over time.
+                    </span>
                 </p>
                 <p>
+                    <span class="rfc2119-assertion" id="arch-action-dataschema">
                     Actions MAY contain data schemas for optional input parameters and output results,
                     if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type).
+                    </span>
                 </p>
                 <p>
                     Examples of Actions are changing multiple Properties simultaneously,
@@ -1749,11 +1783,15 @@ a[href].internalDFN {
                 <p>
                     An Event Interaction Affordance describes an event source that pushes data asynchronously from the Thing to the Consumer.
                     Here not state, but state transitions (i.e., events) are communicated.
+                    <span class="rfc2119-assertion" id="arch-event-trigger">
                     Events MAY be triggered through conditions that are not exposed as Properties.
+                    </span>
                 </p>
                 <p>
+                    <span class="rfc2119-assertion" id="arch-event-dataschema">
                     Events MAY contain data schemas for the event data and possible subscription control messages (e.g., to subscribe with a Webhook callback URI),
                     if the data is not fully specified by the Protocol Binding used (e.g., through a Media Type).
+                    </span>
                 </p>
                 <p>
                     Examples of Events are discrete events such as an alarm or samples of a time series that are pushed regularly.
@@ -1806,9 +1844,13 @@ a[href].internalDFN {
                     Link relation types are either IANA-registered tokens [[IANA-RELATIONS]] adhering to the ABNF [[!RFC5234]]
                     <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code>
                     (e.g., <code>stylesheet</code>) or extension types in the form of URIs [[!RFC3986]].
+                    <span class="rfc2119-assertion" id="arch-rel-types">
                     Extension relation types MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion,
                     character by character.
+                    </span>
+                    <span class="rfc2119-assertion" id="arch-rel-type-lowercase">
                     Because of this, all-lowercase URIs SHOULD be used for extension relation types. [[!RFC8288]]
+                    </span>
                 </p>
                 <p>
                     In the Web of Things, links are used for discovery and to express relations between Things
@@ -1852,15 +1894,21 @@ a[href].internalDFN {
                     " where the optional form fields may further describe the required request.
                 </p>
                 <p>
-                    Form contexts and submission targets are both
+                    <span class="rfc2119-assertion" id="arch-form-iris">
+                    Form contexts and submission targets MUST both be
                     Internationalized Resource Identifiers (IRIs)
-                    [[!RFC3987]]. However, in the common case, they will
+                    [[!RFC3987]]. 
+                    </span>
+                    However, in the common case, they will
                     also be URIs [[!RFC3986]], because many protocols
                     (such as HTTP) do not support IRIs.</p>
-                <p>Form context and submission target MAY point to
+                <p>
+                    <span class="rfc2119-assertion" id="arch-form-iris">
+                    Form context and submission target MAY point to
                     the same resource or different resources, where the
                     submission target resource implements the operation
-                    for the context.</p>
+                    for the context.
+                    </span></p>
                 <p>The operation type identifies the semantics of
                     the operation. Operation types are denoted similar
                     to link relation types:</p>
@@ -1892,16 +1940,23 @@ a[href].internalDFN {
                     </li>
                 </ul>
                 <p>
+                    <span class="rfc2119-assertion" id="arch-op-request-method">
                     The request method MUST identify one method of
                     the standard set of the protocol identified by the
                     submission target URI scheme.
+                    </span>
                 </p>
                 <p>
+                    <span class="rfc2119-assertion" id="arch-op-expected-request">
                     Form fields are optional and MAY further specify the
                     expected request message for the given operation.
+                    </span>
                     Note that this is not limited to the payload, but may affect also protocol headers.
+                    <span class="rfc2119-assertion" id="arch-op-form-fields-protocol">
                     Form fields MAY depend on the protocol used for the
-                    submission target (i.e., URI scheme). Examples are HTTP header fields,
+                    submission target as specified in the URI scheme. 
+                    </span>
+                    Examples are HTTP header fields,
                     CoAP options, the protocol-independent Media Type including parameters (i.e., full content type)
                     for the submission payload, or information about the
                     expected response.
@@ -2016,8 +2071,11 @@ a[href].internalDFN {
                 <h3>Hypermedia-driven</h3>
                 <p>
                     <span class="rfc2119-assertion" id="arch-hypermedia">
-                        Interaction Affordances MUST include one ore more Protocol Bindings, which MUST be serialized as hypermedia controls (see <a
-                        href="#sec-hypermedia-controls"></a>) to to be self-descriptive on how to activate the Interaction Affordance.
+                        Interaction Affordances MUST include one or more Protocol Bindings. 
+                    </span>
+                    <span class="rfc2119-assertion" id="arch-hypermedia-protocol-binding">
+                        Protocol Bindings MUST be serialized as hypermedia controls (see <a
+                        href="#sec-hypermedia-controls"></a>) to be self-descriptive on how to activate the Interaction Affordance.
                     </span>
                     <span class="rfc2119-assertion" id="arch-hypermedia-origin">
                         The hypermedia controls MUST originate from the authority managing the Thing providing the corresponding Interaction Affordance.
@@ -2044,9 +2102,9 @@ a[href].internalDFN {
             <section id="sec-standard-method">
                 <h3>Standard Set of Methods</h3>
                 <p>
-                    <span class="rfc2119-assertion" id="arch-methods">Eligible
-                        protocols for W3C WoT MUST be based on a
-                        standard set of methods that is known a priori.</span>
+                    <span class="rfc2119-assertion" id="arch-methods">
+                        Eligible protocols for W3C WoT MUST be based on a
+                        standard set of methods that are known a priori.</span>
                     The standard set of methods makes messages
                     self-descriptive to enable intermediate processing of
                     interactions, for instance by proxies or to translate
@@ -2080,8 +2138,8 @@ a[href].internalDFN {
                 <p>
                     Note that many Media Types only identify a generic
                     serialization format that does not provide further
-                    semantics for its elements (e.g., XML, JSON, CBOR). <span
-                        class="rfc2119-assertion" id="arch-schema">Thus,
+                    semantics for its elements (e.g., XML, JSON, CBOR). 
+                    <span class="rfc2119-assertion" id="arch-schema">Thus,
                         the corresponding Interaction Affordances SHOULD
                         declare a data schema to provide more detailed
                         semantic metadata for the data exchanged.</span>
@@ -2235,8 +2293,11 @@ a[href].internalDFN {
                    same as the one in the <a>Thing</a>'s TD, or be assigned 
                    an identifier different from the <a>Thing</a>'s, depending 
                    on the requirements of the use cases.
-                   The TD generated by the <a>Intermediary</a> MAY contain 
-                   interfaces for other communication protocols if necessary. </p>
+                   <span class="rfc2119-assertion" id="arch-intermediary-td-extra-protocols">The 
+                   TD generated by an <a>Intermediary</a> MAY contain 
+                   interfaces for other communication protocols if necessary. 
+                   </span>
+                   </p>
 
                    <p>An <a>Intermediary</a> then creates an <a>Exposed Thing</a> 
                    that serves as a bridge to the <a>Thing</a>. A <a>Consumer</a> 


### PR DESCRIPTION
Mark up all RFC2119 assertions so they can be recovered to generate an implementation report.
A few assertions have been reworded to avoid compound sentences or ambiguous pronoun usage.