### PR TITLE
Delete definitions of Security and Privacy

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,11 +441,6 @@ img.wot-arch-diagram {
             <dd>Information that can be associated with a
                 unique individual.</dd>
             <dt>
-                <dfn>Privacy</dfn>
-            </dt>
-            <dd>The system should maintain the
-                confidentiality of <a>Personally Identifiable Information</a>.</dd>
-            <dt>
                 <dfn>Property</dfn>
             </dt>
             <dd>An Interaction Affordance that exposes state of the Thing.
@@ -458,11 +453,6 @@ img.wot-arch-diagram {
             <dd>The mapping from an Interaction Affordance to concrete messages of a specific protocol,
                 thereby informing Consumers how to activate the Interaction Affordance.
                 W3C WoT serializes Protocol Bindings as hypermedia controls.</dd>
-            <dt>
-                <dfn>Security</dfn>
-            </dt>
-            <dd>The system should preserve its integrity
-                and functionality even when subject to attack.</dd>
             <dt>
                 <dfn>Servient</dfn>
             </dt>


### PR DESCRIPTION
NOTE: This PR should only be applied after we have received official TAG feedback and have gotten group consensus.   But it seems likely it will be a recommended change, so I am queuing up a PR for it.

Based on feedback [here](https://github.com/w3ctag/design-reviews/issues/355), remove definitions of the terms "Security" and "Privacy" from the WoT Architecture document.   Note that these terms are, however, defined in the WoT Security and Privacy Guidelines document.

This PR DOES leave the definition for "Personally Identifiable Information" in place.  In a separate issue we may want to find and reference an external definition of this term rather than defining it ourselves.

This PR resolves issue https://github.com/w3c/wot-security/issues/134


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/368.html" title="Last updated on Sep 6, 2019, 7:34 AM UTC (e41264d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/368/44f8dbd...mmccool:e41264d.html" title="Last updated on Sep 6, 2019, 7:34 AM UTC (e41264d)">Diff</a>