### PR TITLE
Update index.html - rename section headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2662,7 +2662,7 @@ img.wot-arch-diagram {
     </section>
 
     <section id="sec-servient-implementation" class="informative">
-        <h1>Servient Implementation</h1>
+        <h1>Abstract Servient Architecture</h1>
         <p>
             As defined in <a href="#sec-wot-servient-architecture-high-level"></a>,
             a <a>Servient</a> is a software stack that implements the WoT building blocks 
@@ -2976,7 +2976,7 @@ img.wot-arch-diagram {
     </section>
 
     <section id="sec-deployment-scenario" class="informative">
-        <h1>WoT Deployments</h1>
+        <h1>Example WoT Deployments</h1>
 
         <p> This section discusses how the Web of Things works as a whole,
             when devices and services that implement <a>Things</a> and <a>Consumers</a> are


### PR DESCRIPTION
Rename section headings for https://github.com/w3c/wot-architecture/issues/392


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/394.html" title="Last updated on Oct 11, 2019, 4:50 AM UTC (a8f5462)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/394/4a1fcb0...a8f5462.html" title="Last updated on Oct 11, 2019, 4:50 AM UTC (a8f5462)">Diff</a>