### PR TITLE
Add privacy paragraph to "Deployment" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2987,9 +2987,12 @@ img.wot-arch-diagram {
     <section id="sec-deployment-scenario" class="informative">
         <h1>Example WoT Deployments</h1>
 
-        <p> This section discusses how the Web of Things works as a whole,
-            when devices and services that implement <a>Things</a> and <a>Consumers</a> are
-            connected together in various topologies and deployment scenarios.
+        <p> This section provides various examples of how the Web of Things (WoT) 
+            abstract architecture may be instantiated 
+            when devices and services that implement the <a>Thing</a> and <a>Consumer</a> roles are
+            connected together in various concrete topologies and deployment scenarios.
+            These topologies and scenarios are not normative, but are permitted and supported
+            by the WoT abstract architecture.
         </p>
         <p>
             Before discussing specific topologies, we will
@@ -3009,7 +3012,7 @@ img.wot-arch-diagram {
                 that are in the roles of <a>Consumers</a> or <a>Intermediaries</a>.
                 TDs may be published in various different ways: the TD
                 might be registered with a management system such as
-                the <a>Thing Directory</a> service, or a <a>Thing</a>
+                a <a>Thing Directory</a> service, or a <a>Thing</a>
                 may provide the requesters with a TD upon receiving a request for a TD.
                 It is even possible to statically associate a TD with <a>Thing</a>
                 in certain application scenarios.
@@ -3019,9 +3022,23 @@ img.wot-arch-diagram {
                 The concrete discovery mechanism depends on the individual deployment scenario:
                 It could be provided by a management system such as a <a>Thing Directory</a>, 
                 a discovery protocol, through static assignment, etc.
-                
-                Internal system functions of a device, such as interacting with attached sensors and actuators,
-                can also optionally be represented as <a>Consumed Thing</a> abstractions.
+            </p>
+            <p> However, it should be noted that TDs describing 
+                devices associated with an indentifiable person may potentially
+                be used to infer privacy-sensitive information.
+                Constraints on the distribution of such TDs must therefore be
+                incorporated into any concrete TD discovery mechanism.  If possible,
+                steps to limit the information exposed in a TD may also have to
+                be taken, such as filtering out IDs or human-readable information
+                if this is not strictly necessary for a particular use case. 
+                Privacy issues are discussed
+                at a high level in <a href="#sec-security-considerations"></a> 
+                and a more detailed discussion is given in the 
+                <a href="https://www.w3.org/TR/wot-thing-description/#sec-security-considerations">Web of Things (WoT) Thing Description</a>
+                specification.
+            </p>
+            <p>Internal system functions of a device, such as interacting with attached sensors and actuators,
+               can also optionally be represented as <a>Consumed Thing</a> abstractions.
             </p>
             <p>The functions supported by the <a>Consumed Thing</a> are provided
                to the <a>Consumer</a>'s behavior implementation through a programming language
@@ -3269,12 +3286,12 @@ img.wot-arch-diagram {
             </figure>
             <p> In more complex situations, not shown in the figure, there
                 may also be cloud services that act as <a>Things</a>.
-                These can also register themselves with the <a>Thing Directory</a>.
+                These can also register themselves with a <a>Thing Directory</a>.
                 Since a <a>Thing Directory</a> is a Web service, it should be visible
                 to the local devices through the NAT or firewall device
                 and its interface can even be provided with its own TD.
                 Local devices acting as <a>Consumers</a> can then
-                discover the <a>Things</a> in the cloud via the <a>Thing Directory</a>
+                discover the <a>Things</a> in the cloud via a <a>Thing Directory</a>
                 and connect to the <a>Things</a> directly or via the local
                 <a>Intermediary</a> if, for instance, protocol translation is needed.
             </p>
@@ -3342,11 +3359,15 @@ img.wot-arch-diagram {
     <section id="sec-security-considerations" class="informative">
         <h1>Security and Privacy Considerations</h1>
         <p>
-            Security is a cross-cutting issue that needs to be considered
+            Security and privacy are a cross-cutting issues that need to be considered
             in all <a href="#sec-building-blocks">WoT
                 building blocks</a> and WoT implementations. This chapter
             summarizes some general issues and guidelines to help
-            preserve the security and privacy of WoT implementations.
+            preserve the security and privacy of concrete WoT implementations.
+            However, these are only general guidelines and an abstract architecture
+            such as described in this document cannot, itself, guarantee security and
+            privacy.
+            Instead the details of a concrete implementation need to be considered.
             For a more detailed and complete analysis of security and
             privacy issues, see the <em>WoT Security and Privacy Guidelines</em>
             specification [[?WOT-SECURITY]].
@@ -3355,11 +3376,18 @@ img.wot-arch-diagram {
             access mechanisms and properties of IoT devices and
             services, including security. In general, W3C WoT is
             designed to describe what exists rather than to prescribe
-            what to implement.
+            what to implement.  A description of an existing system
+            should accurately describe that system, even if it has
+            less than ideal security behavior.  A clear understanding of
+            the security vulnerabilities of a system supports 
+            security mitigations&mdash;although of course such data need
+            not be distributed to those who might maliciously exploit it.
         </p>
         <p>
-            However, the WoT architecture should <em>enable</em> the use
-            of best practices in security and privacy. The WoT security
+            However, especially for new systems, 
+            the WoT architecture should <em>enable</em> the use
+            of best practices in security and privacy. 
+            In general, the WoT security
             architecture must support the goals and mechanisms of the
             IoT protocols and systems it connects to. These systems vary
             in their security requirements and risk tolerance, so
@@ -3368,8 +3396,8 @@ img.wot-arch-diagram {
         <p>Security and privacy are especially important in the IoT
             domain since IoT devices need to operate autonomously and, in
             many cases, have access to both personal data and/or can be
-            in control of safety-critical systems. Compared to personal
-            systems, IoT devices are subject to different and in some
+            in control of safety-critical systems. 
+            IoT devices are subject to different and in some
             cases higher risks than IT systems. It is also important to
             protect IoT systems so that they cannot be used to launch
             attacks on other computer systems.
@@ -3378,7 +3406,7 @@ img.wot-arch-diagram {
             is not possible for the WoT to turn an insecure system into
             a secure one. However, the WoT architecture needs to do
             no harm: it should support security and privacy at least as
-            well as the systems it connects to.
+            well as the systems it describes and supports.
         </p>
         <section id="sec-security-consideration-td-risks">
             <h2>WoT Thing Description Risks</h2>
@@ -3391,7 +3419,8 @@ img.wot-arch-diagram {
             </p>
             <p>Please refer to the Security and Privacy
                 Consideration section of the WoT Thing Description
-                specification for additional details and discussion.</p>
+                specification for additional details and discussion of
+                these points.</p>
             <section id="sec-security-consideration-td-private">
                 <h5>Thing Description Private Security Data Risk</h5>
                 <p>
@@ -3401,7 +3430,7 @@ img.wot-arch-diagram {
                     There should be a strict separation of public and
                     private security data. A TD should contain only
                     public security data, letting Consumers know what
-                    they need to do to access as system if and only if
+                    they need to do to access a system if and only if
                     they have authorization. Authorization in turn
                     should be based on separately managed private
                     information.


### PR DESCRIPTION
NOTE: all changes here included in https://github.com/w3c/wot-architecture/pull/400

- Reword opening paragraph of deployment section to emphasize that these are non-normative examples
- Add a short discussion of privacy right after the introduction of TD discovery and distribution
- Small tweaks to opening of Security and Privacy section

NOTE: originally I did these edits to try to address PLH's concern about mentioning the ID risk, BUT then I realized there would be merge conflicts due to the whole private security data/Private Security Data change, which was still pending.

I therefore created https://github.com/w3c/wot-architecture/pull/400 to merge these changes with the Private Security Data changes... if that PR is merged, this PR should be closed without merging since all the changes here are in that PR, too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/399.html" title="Last updated on Oct 17, 2019, 5:30 AM UTC (1164786)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/399/42b3bf1...mmccool:1164786.html" title="Last updated on Oct 17, 2019, 5:30 AM UTC (1164786)">Diff</a>