### PR TITLE
Make terminology informative - Update

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,7 +432,7 @@ img.wot-arch-diagram {
                 <dfn>Hypermedia Control</dfn>
             </dt>
             <dd>A serialization of a Protocol Binding in hypermedia, that is,
-                either a Web link [[!RFC8288]] for navigation or a Web form for
+                either a Web link [[RFC8288]] for navigation or a Web form for
                 performing other operations. Forms can be seen as request templates
                 provided by the Thing to be completed and sent by the Consumer.</dd>
             <dt>

--- a/index.html
+++ b/index.html
@@ -3707,6 +3707,7 @@ img.wot-arch-diagram {
       <h1>Recent Specification Changes</h1>
       <h2 id="changes-from-candidate-recommendation">Changes from First Candidate Recommendation</h2>
       <ul>
+      <li>Make Terminology section informative.</li>
       <li>Reorganized abstract and introduction.</li>
       <li>Expanded privacy discussion and mitigations.</li>
       <li>Adapted figures to text changes.</li>


### PR DESCRIPTION
Small fixes:
- Remove normative like to RFC8288 from now-informative Terminology section
- Note in change log "Make Terminology section informative"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/404.html" title="Last updated on Oct 22, 2019, 5:02 AM UTC (8b920ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/404/cb32100...8b920ec.html" title="Last updated on Oct 22, 2019, 5:02 AM UTC (8b920ec)">Diff</a>