### PR TITLE
Move stakeholder terms from security doc

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,8 +393,14 @@ img.wot-arch-diagram {
             <dd>A data schema describes the information model and the related payload structure 
 		and corresponding data items that are passed between <a>Things</a> 
 		and <a>Consumers</a> during interactions.</dd>
-            <dt>
-                <dfn>Digital Twin</dfn>
+	     <dt>
+                <dfn>Device Manufacturer</dfn>
+            </dt>
+            <dd>An entity that produces a HW device, which might also implement the <a>WoT Runtime</a>
+		on this device, as well as define <a>Things</a> and respective WoT Thing Descriptions.
+		A Device Manufacturer might also simultaneously be a <a>System Provider</a>.</dd>
+            <dt>		    
+		<dfn>Digital Twin</dfn>
             </dt>
             <dd>A digital twin is a virtual representation of a
                 device or a group of devices that resides on a cloud
@@ -545,6 +551,28 @@ img.wot-arch-diagram {
                 blocks. A Servient can host and expose Things and/or host Consumers that consume Things.
                 Servients can support multiple Protocol Bindings to enable
                 interaction with different IoT platforms.</dd>
+	    <dt>
+                <dfn>System Integrator</dfn>
+            </dt>
+            <dd>An entity that is similar to a <a>System Provider</a> but tends to reuse rather than create new technology.</dd>
+            <dt>
+                <dfn>System Maintainer</dfn>
+            </dt>
+            <dd>An entity that administers a WoT System on behalf of a <a>System Provider</a> or <a>System User</a>.</dd>
+	    <dt>
+                <dfn>System Provider</dfn>
+            </dt>
+            <dd>An entity that uses devices from <a>Device Manufacturer</a>s to build various WoT end solutions
+		specific to particular WoT use case(s). System Providers might define new <a>Things</a> and their respective
+		<a>WoT Thing Descriptions</a> or modify the ones provided by a <a>Device Manufacturer</a>.</dd>
+	    <dt>
+                <dfn>System User</dfn>
+            </dt>
+            <dd>This can be either a physical user (e.g. John in his smart home) or an abstract user
+		(e.g. the company running a factory). The primary characteristic of this stakeholder is the need
+		to use the WoT System to obtain some functionality. System Users entrust WoT Systems with their data 
+                (video streams from home cameras or factory plans) or physical capabilities in the surrounding
+		environment (put lights on in a room or start a machine on the factory line).</dd>
             <dt>
                 <dfn>Subprotocol</dfn>
             </dt>


### PR DESCRIPTION
Moving the basic terms for the stakeholders from the security document


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ereshetova/wot-architecture/pull/418.html" title="Last updated on Dec 23, 2019, 7:39 AM UTC (d766800)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/418/8b554a6...ereshetova:d766800.html" title="Last updated on Dec 23, 2019, 7:39 AM UTC (d766800)">Diff</a>