### PR TITLE
Introduce Partial TD definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,8 +611,8 @@
         A <a>Partial TD</a> is an object that follows the same hierarchical structure of the <a>TD</a> information model, 
         but it may not contain all the mandatory elements. 
         <p class="note">
-          A <a>Partial TD</a> is used in <a>WoT Scripting API</a> as an input for the creation of exposed things. 
-          See the <a href="https://www.w3.org/TR/wot-scripting-api/#the-produce-method">produce</a> method for more details.
+          A <a>Partial TD</a> is used in <a>WoT Scripting API</a> as an input for the creation of <a>Exposed Things</a>. 
+          See the <a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/#the-produce-method">produce</a> method for more details.
         </p>
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -604,6 +604,18 @@
         shared for an entire group of <a>Things</a>. Compared to a Thing Description, a Thing Model does not contain enough 
         information to identify or interact with a Thing instance.</dd>
       <dt>
+      <dt>
+        <dfn>Partial TD</dfn>
+      </dt>
+      <dd>
+        A <a>Partial TD</a> is an object that follows the same hierarchical structure of the <a>TD</a> information model, 
+        but it may not contain all the mandatory elements. 
+        <p class="note">
+          A <a>Partial TD</a> is used in <a>WoT Scripting API</a> as an input for the creation of exposed things. 
+          See the <a href="https://www.w3.org/TR/wot-scripting-api/#the-produce-method">produce</a> method for more details.
+        </p>
+      </dd>
+      <dt>
         <dfn>Transfer Protocol</dfn>
       </dt>
       <dd>The underlying, standardized application layer


### PR DESCRIPTION
I tried to simplify the definition given during the last call. In particular, I dropped the term _subset of_ because it could be understood as if a Partial TD could contain any element of the TD model without any particular order or structure (much like a TD fragment). I also remove the information about the serialization because I found it redundant.  

@ashimura I linked the scripting API document in the _Note_. Did I use the correct link? Should I refer to the published document or the TR is ok? Sorry, I'm still confused a little bit about the publication process.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-architecture/pull/577.html" title="Last updated on Jan 19, 2021, 3:14 PM UTC (b939bd5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/577/591eeb0...relu91:b939bd5.html" title="Last updated on Jan 19, 2021, 3:14 PM UTC (b939bd5)">Diff</a>