### PR TITLE
Add terminology from binding templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,6 +583,13 @@
         including communication metadata of WoT Binding
         Templates.</dd>
       <dt>
+        <dfn>TD Context Extension</dfn>
+      </dt>
+      <dd>A mechanism to extend <a>Thing Descriptions</a> with additional <a>Vocabulary
+        Terms</a> using <code>@context</code> as specified in JSON-LD[[?JSON-LD11]]. 
+        It is the basis for semantic annotations and extensions to core
+      mechanisms such as Protocol Bindings, Security Schemes, and Data Schemas.</dd>
+      <dt>
         <dfn>Thing</dfn> or <dfn>Web Thing</dfn>
       </dt>
       <dd>An abstraction of a physical or a virtual entity
@@ -641,6 +648,23 @@
       </dt>
       <dd>An instance of a Thing that represents a Thing that is located
         on another system component.</dd>
+      <dt>
+        <dfn>Vocabulary</dfn>
+      </dt>
+      <dd>
+        A collection of <a>Vocabulary Terms</a>, identified by a namespace IRI.
+      </dd>
+      <dt>
+        <dfn>Term</dfn>
+        and
+        <dfn>Vocabulary Term</dfn>
+      </dt>
+      <dd>
+        A character string. When a <a>Term</a> is part of a <a>Vocabulary</a>, i.e., prefixed by
+        a namespace IRI[[RFC3987]], it is called a <a>Vocabulary Term</a>. For the sake of readability,
+        <a>Vocabulary Terms</a> present in this document are always written in a compact
+        form and not as full IRIs.
+      </dd>
       <dt>
         <dfn>WoT Interface</dfn>
       </dt>


### PR DESCRIPTION
As discussed in the call of 22.03.2021, this PR moves terminology from binding templates to here


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/egekorkan/wot-architecture/pull/586.html" title="Last updated on Mar 22, 2021, 1:31 PM UTC (7fe266c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/586/c0c8113...egekorkan:7fe266c.html" title="Last updated on Mar 22, 2021, 1:31 PM UTC (7fe266c)">Diff</a>