### PR TITLE
Move Partial TD definition to right place in list

### DIFF
--- a/index.html
+++ b/index.html
@@ -502,6 +502,16 @@
         We use the same definition as [[ISO-IEC-29100]].
       </dd>
       <dt>
+        <dfn>Partial TD</dfn>
+      </dt>
+      <dd>
+        A <a>Partial TD</a> is an object that follows the same hierarchical structure of the <a>TD</a> information model, 
+        but it is not required to contain all the mandatory elements. 
+        <p class=note>
+          An example usage of a <a>Partial TD</a> is in <a>WoT Scripting API</a> as an input for the creation of <a>Exposed Things</a>. 
+          See the <a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/#the-produce-method">produce</a> method for more details.
+        </p></dd>
+      <dt>
         <dfn>Privacy</dfn>
       </dt>
       <dd>Freedom from intrusion into the private life or affairs of an individual when that intrusion results from
@@ -602,16 +612,6 @@
         capabilities. It describes the <a>Properties</a>, <a>Actions</a>, and <a>Events</a> and common metadata that are 
         shared for an entire group of <a>Things</a>. Compared to a Thing Description, a Thing Model does not contain enough 
         information to identify or interact with a Thing instance.</dd>
-      <dt>
-        <dfn>Partial TD</dfn>
-      </dt>
-      <dd>
-        A <a>Partial TD</a> is an object that follows the same hierarchical structure of the <a>TD</a> information model, 
-        but it is not required to contain all the mandatory elements. 
-        <p class=note>
-          An example usage of a <a>Partial TD</a> is in <a>WoT Scripting API</a> as an input for the creation of <a>Exposed Things</a>. 
-          See the <a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/#the-produce-method">produce</a> method for more details.
-        </p></dd>
       <dt>
         <dfn>TD Fragment</dfn>
       </dt>


### PR DESCRIPTION
all the others seems to be sorted sorted lexicographically

see its current place, https://w3c.github.io/wot-architecture/#dfn-partial-td


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/590.html" title="Last updated on Apr 22, 2021, 9:59 AM UTC (afaa7f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/590/42655e7...afaa7f0.html" title="Last updated on Apr 22, 2021, 9:59 AM UTC (afaa7f0)">Diff</a>