### PR TITLE
Fixup Device Classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,6 +731,80 @@
 
   </section>
 
+  <!-- Device categories -->
+  <section id="device-categoriesdevices">
+      <h2>Device Categories</h2>	  
+      <p>
+        In a deployment of WoT conforming to the <a href="https://www.w3.org/TR/wot-architecture/#architecture-abstract">WoT Abstract Architecture</a>
+        we see different device types with typical characteristics.
+        They range (sorted in the order of footprint and capabilities) 
+        from small embedded <em>node</em> devices to <em>gateways</em> or <em>hubs</em> 
+        to powerful <em>edge</em> devices and <em>cloud</em> servers.
+        Interoperability between these devices implies that a core set of features and functionalities
+        is available on <em>all</em> of them.
+      </p>
+      
+      <p>The following device categories describe the footprint and characteristics of typical representants of these classes.
+       This is used to identify the possible features and use cases for these device classes.</p>
+      
+       <p>
+      We are aligned with the classes defined by the IETF [[RFC7228]] for constrained devices,
+      however put the bounds on typical sizes of RAM / Flash in the real world.
+      Note that this is not a strict categorisation, categories may overlap and not all memory may be available for user applications.</p>
+      
+      <table>
+      <tr>
+        <th>Category</th> 
+        <th>data size (RAM)</th>
+        <th>code size (Flash, ROM, ...)</th>
+        <th>Typical Representant</th>
+      </tr>  
+      <tr>
+        <td>Class-0, C0</td>
+        <td><< 10 KiB</td>
+        <td><< 100 KiB</td>
+        <td>unsecure sensor nodes</td>
+      </tr>
+      <tr>
+        <td>Class-1, C1</td>
+        <td>~ 10 KiB</td>
+        <td>~ 100 KiB</td>
+        <td>secure sensor node</td>
+      </tr><tr>
+        <td>Class-2, C2</td>
+        <td>~ 64 KiB</td>
+        <td>~ 256 KiB</td>
+        <td>nodeMCU</td>
+      </tr>
+      </tr><tr>
+        <td>Class-3, C3</td>
+        <td>~ 64-256 KiB</td>
+        <td>~ 256 KiB - several MBs</td>
+        <td>ISP gateway</td>
+      </tr>
+      </tr><tr>
+        <td>Class-4, C4</td>
+        <td>~  256 KiB -  several MB</td>
+        <td>~  1 MB - several MB</td>
+        <td>gateway/hub</td>
+      </tr>
+      </tr><tr>
+        <td>Class-5, C5</td>
+        <td>~ 1 GB</td>
+        <td>~ 1 GB</td>
+        <td>edge</td>
+      </tr>
+      </tr><tr>
+        <td>Class-6, C6</td>
+        <td>~ several GB</td>
+        <td>~ several GB</td>
+        <td>cloud</td>
+      </tr>
+      </table>
+      
+      </p>
+        </section>
+
   <section id="sec-application-domains" class="informative">
     <h2>Application Domains (Verticals)</h2>
     <p>
@@ -2662,79 +2736,6 @@
 
         </section>
 
-        <!-- Device categories -->
-        <section id="device-categoriesdevices">
-          <h2>Device Categories</h2>	  
-      <p>
-        In a deployment of WoT conforming to the <a href="https://www.w3.org/TR/wot-architecture/#architecture-abstract">WoT Abstract Architecture</a>
-        we see different device types with typical characteristics.
-        They range (sorted in the order of footprint and capabilities) 
-        from small embedded <em>node</em> devices to <em>gateways</em> or <em>hubs</em> 
-        to powerful <em>edge</em> devices and <em>cloud</em> servers.
-        Interoperability between these devices implies that a core set of features and functionalities
-        is available on <em>all</em> of them.
-      </p>
-      
-      <p>The following device categories describe the footprint and characteristics of typical representants of these classes.
-       This is used to identify the possible features and use cases for these device classes.</p>
-      
-       <p>
-      We are aligned with the classes defined by the IETF [[RFC7228]] for constrained devices,
-      however put the bounds on typical sizes of RAM / Flash in the real world.
-      Note that this is not a strict categorisation, categories may overlap and not all memory may be available for user applications.</p>
-      
-      <table>
-      <tr>
-        <th>Category</th> 
-        <th>data size (RAM)</th>
-        <th>code size (Flash, ROM, ...)</th>
-        <th>Typical Representant</th>
-      </tr>  
-      <tr>
-        <td>Class-0, C0</td>
-        <td><< 10 KiB</td>
-        <td><< 100 KiB</td>
-        <td>unsecure sensor nodes</td>
-      </tr>
-      <tr>
-        <td>Class-1, C1</td>
-        <td>~ 10 KiB</td>
-        <td>~ 100 KiB</td>
-        <td>secure sensor node</td>
-      </tr><tr>
-        <td>Class-2, C2</td>
-        <td>~ 64 KiB</td>
-        <td>~ 256 KiB</td>
-        <td>nodeMCU</td>
-      </tr>
-      </tr><tr>
-        <td>Class-3, C3</td>
-        <td>~ 64-256 KiB</td>
-        <td>~ 256 KiB - several MBs</td>
-        <td>ISP gateway</td>
-      </tr>
-      </tr><tr>
-        <td>Class-4, C4</td>
-        <td>~  256 KiB -  several MB</td>
-        <td>~  1 MB - several MB</td>
-        <td>gateway/hub</td>
-      </tr>
-      </tr><tr>
-        <td>Class-5, C5</td>
-        <td>~ 1 GB</td>
-        <td>~ 1 GB</td>
-        <td>edge</td>
-      </tr>
-      </tr><tr>
-        <td>Class-6, C6</td>
-        <td>~ several GB</td>
-        <td>~ several GB</td>
-        <td>cloud</td>
-      </tr>
-      </table>
-      
-      </p>
-        </section>
       
 
     <section id="core-profile">

--- a/index.html
+++ b/index.html
@@ -761,8 +761,8 @@
       </tr>  
       <tr>
         <td>Class-0, C0</td>
-        <td><< 10 KiB</td>
-        <td><< 100 KiB</td>
+        <td>&lt;&lt; 10 KiB</td>
+        <td>&lt;&lt; 100 KiB</td>
         <td>unsecure sensor nodes</td>
       </tr>
       <tr>

--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@
       <h2>Device Categories</h2>	  
       <p>
         In a deployment of WoT conforming to the <a href="https://www.w3.org/TR/wot-architecture/#architecture-abstract">WoT Abstract Architecture</a>
-        we see different device types with typical characteristics.
+        we see a variety of different device types.
         They range (sorted in the order of footprint and capabilities) 
         from small embedded <em>node</em> devices to <em>gateways</em> or <em>hubs</em> 
         to powerful <em>edge</em> devices and <em>cloud</em> servers.
@@ -744,37 +744,46 @@
         is available on <em>all</em> of them.
       </p>
       
-      <p>The following device categories describe the footprint and characteristics of typical representants of these classes.
-       This is used to identify the possible features and use cases for these device classes.</p>
+      <p> 
+        The following device categories describe the footprint and characteristics of 
+        typical representatives of these classes.
+        This is used to identify the possible features and use cases for these device classes.
+      </p>
       
-       <p>
-      We are aligned with the classes defined by the IETF [[RFC7228]] for constrained devices,
-      however put the bounds on typical sizes of RAM / Flash in the real world.
-      Note that this is not a strict categorisation, categories may overlap and not all memory may be available for user applications.</p>
+      <p> 
+        These categories are aligned with the classes defined by the IETF [[RFC7228]] for constrained devices,
+        however the classes have been extended to larger devices and 
+        bounds on typical sizes of RAM and Flash/ROM are provided.  
+        Memory and storage size are both easier to quantify and more limiting than performance, 
+        so that is the basis of this categorization.
+        This is not a strict categorisation.
+        Categories may overlap and not all memory may be available for user applications.
+      </p>
       
       <table>
       <tr>
         <th>Category</th> 
         <th>data size (RAM)</th>
         <th>code size (Flash, ROM, ...)</th>
-        <th>Typical Representant</th>
+        <th>Typical Representative</th>
       </tr>  
       <tr>
         <td>Class-0, C0</td>
         <td>&lt;&lt; 10 KiB</td>
         <td>&lt;&lt; 100 KiB</td>
-        <td>unsecure sensor nodes</td>
+        <td>unsecure sensor nodes</td> <!-- could call this a "microcontroller" -->
       </tr>
       <tr>
         <td>Class-1, C1</td>
         <td>~ 10 KiB</td>
         <td>~ 100 KiB</td>
-        <td>secure sensor node</td>
+        <td>secure sensor node</td> <!-- could just call this a "node" or "basic node" -->
       </tr><tr>
         <td>Class-2, C2</td>
         <td>~ 64 KiB</td>
         <td>~ 256 KiB</td>
-        <td>nodeMCU</td>
+        <td>nodeMCU</td> 
+        <!-- could just call this an "advanced node" or just a "node" if above is "basic node" -->
       </tr>
       </tr><tr>
         <td>Class-3, C3</td>
@@ -801,9 +810,18 @@
         <td>cloud</td>
       </tr>
       </table>
-      
+
+      <p class="ednote" title="Category Names">
+      Category names should be further discussed.  
+      In particular, a NodeMCU is a particular product
+      and either we should not use it, or give similar (and multiple) examples in the other
+      categories.  
+      We can also leave security out of the names but perhaps discuss it 
+      an expected protocol support separately
+      (i.e. which classes we expect to be the minimum necessary to support TLS/HTML/HTTP, DTLS/CoAP, etc),
+      as it's not black and white (which unsecure/secure implies).
       </p>
-        </section>
+  </section>
 
   <section id="sec-application-domains" class="informative">
     <h2>Application Domains (Verticals)</h2>

--- a/index.html
+++ b/index.html
@@ -2679,7 +2679,7 @@
        This is used to identify the possible features and use cases for these device classes.</p>
       
        <p>
-      We are aligned with the classes defined in https://tools.ietf.org/html/rfc7228 for constrained devices,
+      We are aligned with the classes defined by the IETF [[RFC7228]] for constrained devices,
       however put the bounds on typical sizes of RAM / Flash in the real world.
       Note that this is not a strict categorisation, categories may overlap and not all memory may be available for user applications.</p>
       

--- a/index.html
+++ b/index.html
@@ -2717,7 +2717,7 @@
         <td>Class-4, C4</td>
         <td>~  256 KiB -  several MB</td>
         <td>~  1 MB - several MB</td>
-        <td>gateway</td>
+        <td>gateway/hub</td>
       </tr>
       </tr><tr>
         <td>Class-5, C5</td>


### PR DESCRIPTION
Resolves https://github.com/w3c/wot-architecture/issues/598

- [x] fix reference to RFC7228
- [x] use "gateway/hub" for Class 4
- [x] Move section to more appropriate location (it's not really a building block; perhaps move under Terminology?)
- [x] General grammar and positioning cleanup (e.g. sentence in which RFC is cited is confusing)


Note: "hub" is only mentioned in this section now and no-where else.  So the definition of hub also needs to be addressed, but this should be dealt with in a different PR that addresses issue https://github.com/w3c/wot-architecture/issues/581


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/601.html" title="Last updated on Jul 15, 2021, 1:46 PM UTC (a5dfece)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/601/af1a8df...mmccool:a5dfece.html" title="Last updated on Jul 15, 2021, 1:46 PM UTC (a5dfece)">Diff</a>