### PR TITLE
Add observeallproperties, unobserveallproperties, subscribeallevents and unsubscribeallevents

### DIFF
--- a/index.html
+++ b/index.html
@@ -2234,6 +2234,27 @@
                   operation on Things to update the
                   data of selected writable Properties in a single interaction.</td>
               </tr>
+                <td>observeallproperties</td>
+                <td>Identifies the observeallproperties operation on
+                  Properties to be notified with new data when any Property is
+                  updated.</td>
+              </tr>
+              </tr>
+                <td>unobserveallproperties</td>
+                <td>Identifies the unobserveallproperties operation on
+                  Properties to stop notifications from all Properties in a 
+                  single interaction.</td>
+              </tr>
+              </tr>
+                <td>subscribeallevents</td>
+                <td>Identifies the subscribeallevents operation on Events to subscribe
+                  to notifications from all Events in a single interaction.</td>
+              </tr>
+              </tr>
+                <td>unsubscribeallevents</td>
+                <td>Identifies the unsubscribeallevents operation on Events to unsubscribe
+                  from notifications from all Events in a single interaction.</td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Counterpart to https://github.com/w3c/wot-thing-description/pull/1191 in the Thing Description specification, to add descriptions for the `subscribeallevents` and `unsubscribeallevents` operations, as discussed in https://github.com/w3c/wot-thing-description/issues/1082.

Also adds descriptions for the missing `observeallproperties` and `unobserveallproperties` operations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-architecture/pull/605.html" title="Last updated on Jul 19, 2021, 1:54 PM UTC (740aadc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/605/af1a8df...benfrancis:740aadc.html" title="Last updated on Jul 19, 2021, 1:54 PM UTC (740aadc)">Diff</a>