### PR TITLE
remove arch-methods assertion and section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2537,21 +2537,6 @@
           W3C WoT refers to these protocols as <a>transport protocols</a>.
         </p>
       </section>
-      <section id="sec-standard-method">
-        <h3>Standard Set of Methods</h3>
-        <p>
-          <span class="rfc2119-assertion" id="arch-methods">
-            Eligible protocols for W3C WoT MUST be based on a
-            standard set of methods that are known a priori.</span>
-          The standard set of methods makes messages
-          self-descriptive to enable intermediate processing of
-          <a>Interaction Affordance</a>s, for instance by proxies or to translate
-          between Protocol Bindings [[?REST]]. Furthermore, it
-          allows <a>Consumers</a> to have re-usable protocol
-          stacks of common <a>transport protocols</a> such as HTTP, CoAP, or MQTT,
-          avoiding Thing-specific code or plugins for <a>Consumers</a>.
-        </p>
-      </section>
       <section id="media-types">
         <h3>Media Types</h3>
         <p>


### PR DESCRIPTION
I've been assigned to #640. With this PR I'm following the consensus reached of removing the assertion from the document. Notice that I remove the section completely because I wasn't sure to leave it there without a proper assertion.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-architecture/pull/650.html" title="Last updated on Dec 3, 2021, 9:37 AM UTC (4a42d16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/650/1f4a8b8...relu91:4a42d16.html" title="Last updated on Dec 3, 2021, 9:37 AM UTC (4a42d16)">Diff</a>