### PR TITLE
Remove `arch-consumer-configuration`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1689,8 +1689,6 @@
           MAY be bundled together with a Consumer to enable Thing-to-Thing interaction.</span>
         Usually, the Consumer behavior is embedded in the software component,
         which is also implementing the behavior of the Thing.
-        <span class="rfc2119-assertion" id="arch-consumer-configuration">The
-          configuration of the Consumer behavior MAY be exposed through the Thing.</span>
       </p>
       <p>
         The concepts of W3C WoT are applicable to all levels relevant for IoT applications: the device level, edge


### PR DESCRIPTION
(Fixes #636 )
Based on the discussion on Nov. 25, I've removed the assertion `arch-consumer-configuration`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-architecture/pull/651.html" title="Last updated on Dec 6, 2021, 4:27 AM UTC (9d0e1b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/651/1f4a8b8...k-toumura:9d0e1b1.html" title="Last updated on Dec 6, 2021, 4:27 AM UTC (9d0e1b1)">Diff</a>