### PR TITLE
Remove an assertion `arch-hypermedia-origin`

### DIFF
--- a/index.html
+++ b/index.html
@@ -2505,11 +2505,7 @@
             Protocol Bindings MUST be serialized as <a href="#sec-hypermedia-controls">hypermedia controls</a> to be self-descriptive on how to
             activate the Interaction Affordance.
           </span>
-          <span class="rfc2119-assertion" id="arch-hypermedia-origin">
-            The hypermedia controls MUST originate from the authority managing the Thing that is providing the
-            corresponding Interaction Affordance.
-          </span>
-          The authority can be the <a>Thing</a> itself, producing the <a>TD</a> document
+          The authority of the hypermedia controls can be the <a>Thing</a> itself, producing the <a>TD</a> document
           at runtime (based on its current state and including network parameters such as its IP address)
           or serving it from memory with only the current network parameters inserted.
           The authority can also be an external entity that has full and up-to-date knowledge of the <a>Thing</a>


### PR DESCRIPTION
Fixes #641 

Based on discussion in #641, removed an assertion `arch-hypermedia-origin`.