### PR TITLE
remove remove-arch-op-wellknown-compare assertion

### DIFF
--- a/index.html
+++ b/index.html
@@ -2320,9 +2320,6 @@
               Well-known operation types MUST follow the ABNF
               <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code>.
             </span>
-            <span class="rfc2119-assertion" id="arch-op-wellknown-compare">
-              Well-known operation types MUST be compared using a case-insensitive comparison.
-            </span>
             The well-known operation types for the Web of Things defined by this specification are given in <a
               href="#table-operation-types">Table 1</a>.
           </li>


### PR DESCRIPTION
This should only be merged after the TD specification contains a clarification about the handling of uppercase/lowercase vocabulary terms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/668.html" title="Last updated on Jan 18, 2022, 7:56 AM UTC (646df83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/668/8645973...646df83.html" title="Last updated on Jan 18, 2022, 7:56 AM UTC (646df83)">Diff</a>