### PR TITLE
fix: some typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -696,7 +696,7 @@
 	defined in chapter 5 of the TD spec, however the fragment may omit some context that allows full validation.
 
         <p class=note>
-	In JSON represention it must be a valid JSON document, however could be just an inner structure 
+	In JSON representation it must be a valid JSON document, however could be just an inner structure 
 	omitting outer elements, curly braces etc. present in a full TD.
 		
 	As a use case the <a>TD Fragment</a> is useful for <a>Discovery</a> results returned by a JSON-Path query.
@@ -799,7 +799,7 @@
         bounds on typical sizes of RAM and Flash/ROM are provided.  
         Memory and storage size are both easier to quantify and more limiting than performance, 
         so that is the basis of this categorization.
-        This is not a strict categorisation.
+        This is not a strict categorization.
         Categories may overlap and not all memory may be available for user applications.
       </p>
       
@@ -1614,7 +1614,7 @@
           A <em>Thing Model</em>  enables the opportunity to define the basic information model 
 	  of a <a>Thing</a> to address such kind of scenarios.
           <em>Thing Model</em> can be seen as a template for <a>Thing Descriptions</a>, however, that have less restriction as 
-          defined in sections "TD Information Model"and section "Representation Format" 
+          defined in sections "TD Information Model" and "Representation Format" 
           of the [[?WOT-THING-DESCRIPTION]]. Typically <a>Thing Model</a> examples 
           does not contain any instance-specific information such as protocol specific data like IP addresses. 
           However, instead of having, e.g., concrete URLs, 
@@ -1855,7 +1855,7 @@
           This may include the provisioning of keys, performing configuration operations, onboarding it to a consumer,
           registering it with a thing directory and other actions.
           When a thing has to be permanently removed from an application, the system has to undergo some state changes
-          to decomission it from consumers,
+          to decommission it from consumers,
           remove security credentials, deregister it from directories etc.
           These activities change the state of individual system components which impact the entire system state.
           For example a thing, that has been deregistered from a directory service can no longer be looked up.
@@ -2902,7 +2902,7 @@
         are designed to protect queries about such data and metadata, and
         to avoid accidental distribution of direct or inferrable metadata.  
         </p><p>
-        In order to accomodate existing discovery technologies while providing
+        In order to accommodate existing discovery technologies while providing
         strong privacy and security, <a>WoT Discovery</a> uses a two-stage process.
         In the first stage, an "<a>introduction</a>" is made using one of several
         first-contact mechanisms.  
@@ -3988,7 +3988,7 @@
             For example, explicit type and instance identifying information in TDs should
             also not be included if it is not needed by the use case.
             Even if required by the use case,
-            to mimimize tracking risks, distributed and limited-scope
+            to minimize tracking risks, distributed and limited-scope
             identifiers should be used whenever possible rather than
             globally unique identifiers.
             Other forms of information,


### PR DESCRIPTION
represention --> representation

categorisation --> categorization ... used line before with z

"TD Information Model"and section    --> "TD Information Model" and

decomission 	--> decommission

accomodate 	--> accommodate

mimimize 	--> minimize


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-architecture-1/pull/683.html" title="Last updated on Jan 27, 2022, 4:22 PM UTC (24b883f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/683/737fc23...danielpeintner:24b883f.html" title="Last updated on Jan 27, 2022, 4:22 PM UTC (24b883f)">Diff</a>