### PR TITLE
Update Implementation Report link in SOTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       shortName: "wot-architecture11",
       copyrightStart: 2017,
       wgPublicList: "public-wot-wg",
+      implementationReportURI: "https://w3c.github.io/wot-architecture/testing/report.html",
       github: {
         repoURL: "https://github.com/w3c/wot-architecture",
         branch: "master"

--- a/index.html
+++ b/index.html
@@ -285,10 +285,11 @@
     <p>
       This document describes an abstract architecture design.
       However, there is an
-      <a href="https://w3c.github.io/wot-thing-description/testing/report.html">Implementation Report</a>
-      that describes a set of concrete implementations based on the associated <em>WoT Thing Description</em>
-      specification.
-      These are implementations following the W3C Web of Things architecture.
+      <a href="https://w3c.github.io/wot-architecture/testing/report.html">Implementation Report</a>
+      that describes a set of concrete implementations 
+      following the W3C Web of Things architecture.
+      It also references the other implementation
+      reports for the various WoT building blocks.
     </p>
   </section>
   <section id="introduction" class="informative">


### PR DESCRIPTION
Resolves #699 
- Links to (new) Architecture IR (still to be created...) in SOTD
- Links to Architecture IR in header, consistent with other docs
- Says that Architecture IR describes implementations following the architecture
- Says that Architecture IR links to other IRs for building blocks
So when we do write the Arch IR, we need to remember to do the last two points.  The alternative would be to link to each of the building blocks' IRs directly from the Architecture SOTD but I think that will just clutter things up.  They are also linked from the header of each document (or should be).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/701.html" title="Last updated on Feb 3, 2022, 2:31 AM UTC (4f83abb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/701/7368123...mmccool:4f83abb.html" title="Last updated on Feb 3, 2022, 2:31 AM UTC (4f83abb)">Diff</a>