### PR TITLE
WIP: Explainer for Architecture 1.1

### DIFF
--- a/explainer/Explainer11.md
+++ b/explainer/Explainer11.md
@@ -1,0 +1,8 @@
+Initial placeholder for material to be refactored from TD 1.0 explainer.
+See https://github.com/w3c/wot-thing-description/pull/1397
+
+Needed for wide review.  Suggest that we use the Architectural explainer for general introductions, and 
+TD, Discovery, and Profile explainers to add detail and provide use cases, justifications, requirements,
+and examples for their specific deliverables.
+
+See above PR for links to instructions for writing explainers.


### PR DESCRIPTION
Initial placeholder for material to be refactored from TD 1.0 explainer.

See https://github.com/w3c/wot-thing-description/pull/1397

Will update this PR (e.g. with To Do list) after we discuss proposed refactoring plan.
Note that the name "Explainer11.md" is meant to be consistent with the use of versions elsewhere, e.g. in the TD spec.
We may want to add a simple "Explainer.md" file as well here that just links to the one under the TD repo (used for Architecture 1.0) so that people can find it.