### PR TITLE
Definitions for Device, Service, etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,17 +447,16 @@
       <dt>
         <dfn>Digital Twin</dfn>
       </dt>
-      <dd>A digital twin is type of <a>Virtual Thing</a>,
-        specifically
-        a <a>Service</a> that resides on a cloud or edge node 
-	and represents another device or a group of devices.
-	Digital Twins can be used to represent and provide 
+      <dd>A digital twin is type of <a>Virtual Thing</a>
+        that resides on a cloud or edge node. 
+	Digital Twins may be used to represent and provide 
 	a network interface for
-        real-world devices which may not be continuously online,
-        or to run simulations of new applications and services
-        before they get deployed to the real devices.
-	They may also be used to maintain a history of past
-	state or behviour or to predict future state of behaviour.
+        real-world devices which may not be continuously online
+	(see also <a>Shadows</a>),
+        may be able to run simulations of new applications and services
+        before they get deployed to the real devices,
+	may be able to maintain a history of past state or behaviour, 
+	and may be able to predict future state or behaviour.
 	Digital Twins typically have more functionality than
 	simple <a>Shadows</a>.
       </dd>
@@ -646,6 +645,18 @@
         blocks. A Servient can host and expose Things and/or host Consumers that consume Things.
         Servients can support multiple Protocol Bindings to enable
         interaction with different IoT platforms.</dd>
+      <dt>
+        <dfn>Shadow</dfn>
+      </dt>
+      <dd>A Shadow is a <a>Virtual Thing</a> that
+      maintains a copy of the state and mediates interactions with another
+      <a>Thing</a> which may not be immediately available due to network
+      connectivity, power savings modes, or other factors.
+      A Shadow aims to achive eventual consistency with the state
+      of the Thing it represents.
+      If a Shadow has more advanced functionality than simply caching state
+      it may be better to refer to it as a <a>Digital Twin</a>.
+      </dd>
       <dt>
         <dfn>Subprotocol</dfn>
       </dt>

--- a/index.html
+++ b/index.html
@@ -4319,13 +4319,15 @@
 
     <h2 id="changes-from-recommendation-1.0">Changes from the 1.0 version of [[wot-architecture]]</h2>
     <ul>
-      <li>Add definitions for Device, Service, and Shadow.  Update definitions for
-	  Virtual Thing and Digital Twin.  Narrow definition of Virtual Thing to
-	  a Service that represents another Thing.</li>
+      <li>Add definitions for Connected Device (a.k.a. Device), Service, and Shadow.  
+	  Update definitions for
+	  Virtual Thing and Digital Twin.  
+	  Narrow definition of Virtual Thing to
+	  a Service that mediates with one of more other Things.</li>
       <li>Split Security and Privacy Considerations into separate chapters.</li>
       <li>New chapter: Lifecycle.</li>
       <li>New terminology: Thing Model.</li>
-      <li>Chapter restructuring and renaming
+      <li>Chapter restructuring and renaming:
         <ul>
           <li>Application Domains (Verticals)</li>
           <li>System Topologies (Horizontals)</li>

--- a/index.html
+++ b/index.html
@@ -4304,10 +4304,13 @@
 
     <h2 id="changes-from-recommendation-1.0">Changes from the 1.0 version of [[wot-architecture]]</h2>
     <ul>
+      <li>Add definitions for Device, Service, and Shadow.  Update definitions for
+	  Virtual Thing and Digital Twin.  Narrow definition of Virtual Thing to
+	  a Service that represents another Thing.</li>
       <li>Split Security and Privacy Considerations into separate chapters.</li>
       <li>New chapter: Lifecycle.</li>
       <li>New terminology: Thing Model.</li>
-      <li>Chapter restructuring and renaming:
+      <li>Chapter restructuring and renaming
         <ul>
           <li>Application Domains (Verticals)</li>
           <li>System Topologies (Horizontals)</li>

--- a/index.html
+++ b/index.html
@@ -445,6 +445,12 @@
         and corresponding data items that are passed between <a>Things</a>
         and <a>Consumers</a> during interactions.</dd>
       <dt>
+        <dfn>Device</dfn>
+      </dt>
+      <dd>A Device is a physical entity that has a network interface.
+      Devices can be described by a <a>Thing Description</a> and are a kind of <a>Thing</a>.
+      Compare with <a>Service</a>.
+      <dt>
         <dfn>Digital Twin</dfn>
       </dt>
       <dd>A digital twin is type of <a>Virtual Thing</a>

--- a/index.html
+++ b/index.html
@@ -669,11 +669,14 @@
       </dt>
       <dd>A Shadow is a <a>Virtual Thing</a> that
       maintains a copy of the state and mediates interactions with another
-      <a>Thing</a> which may not be immediately available due to network
+      <a>Thing</a>.
+      <!--
+      which may not be immediately available due to network
       connectivity, power savings modes, or other factors.
-      A Shadow aims to achive eventual consistency with the state
+      -->
+      A Shadow aims to achieve eventual consistency with the state
       of the Thing it represents.
-      If a Shadow has more advanced functionality than simply caching state
+      If a Shadow has more functionality than simply mirroring state
       it may be better to refer to it as a <a>Digital Twin</a>.
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -447,12 +447,20 @@
       <dt>
         <dfn>Digital Twin</dfn>
       </dt>
-      <dd>A digital twin is a virtual representation of a
-        device or a group of devices that resides on a cloud
-        or edge node. It can be used to represent
+      <dd>A digital twin is type of <a>Virtual Thing</a>,
+        specifically
+        a <a>Service</a> that resides on a cloud or edge node 
+	and represents another device or a group of devices.
+	Digital Twins can be used to represent and provide 
+	a network interface for
         real-world devices which may not be continuously online,
-        or to run simulations of new applications and services,
-        before they get deployed to the real devices.</dd>
+        or to run simulations of new applications and services
+        before they get deployed to the real devices.
+	They may also be used to maintain a history of past
+	state or behviour or to predict future state of behaviour.
+	Digital Twins typically have more functionality than
+	simple <a>Shadows</a>.
+      </dd>
       <dt><dfn data-lt="WoT Discovery">Discovery</dfn>
       <dd>Mechanisms defined by WoT for distributing and accessing
         <a>WoT Thing Descriptions</a> on the network, 

--- a/index.html
+++ b/index.html
@@ -735,8 +735,10 @@
       <dt>
         <dfn>Virtual Thing</dfn>
       </dt>
-      <dd>An instance of a Thing that represents a Thing that is located
-        on another system component.</dd>
+      <dd>A <a>Service</a> that represents another <a>Thing</a>.
+       A Virtual Thing will often as as an <a>Intermediary</a>.
+       Examples include <a>Shadows</a> and <a>Digital Twins</a>.
+      </dd>
       <dt>
         <dfn>Vocabulary</dfn>
       </dt>

--- a/index.html
+++ b/index.html
@@ -748,8 +748,14 @@
       <dt>
         <dfn>Virtual Thing</dfn>
       </dt>
-      <dd>A <a>Service</a> that represents another <a>Thing</a>.
-       A Virtual Thing will often as as an <a>Intermediary</a>.
+      <dd>A <a>Service</a> that 
+       represents,
+       augments the functionality of,
+       provides an improved interface to,
+       or 
+       stands in place of
+       one or more other <a>Things</a>.
+       A Virtual Thing will often act as an <a>Intermediary</a>.
        Examples include <a>Shadows</a> and <a>Digital Twins</a>.
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -449,7 +449,7 @@
       </dt>
       <dd>A Device is a physical entity that has a network interface.
       Devices can be described by a <a>Thing Description</a> and are a kind of <a>Thing</a>.
-      Compare with <a>Service</a>.
+      Compare with <a>Service</a>.</dd>
       <dt>
         <dfn>Digital Twin</dfn>
       </dt>
@@ -644,6 +644,13 @@
       </dt>
       <dd>The combination of Public Security Metadata, Private Security Data, and any other configuration
         information (such as public keys) necessary to operationally configure the security mechanisms of a Thing.</dd>
+      <dt>
+        <dfn>Service</dfn>
+      </dt>
+      <dd>A Service is a software entity that has a network interface.
+      Services can be described by a <a>Thing Description</a> and are a kind of <a>Thing</a>.
+      See also <a>Virtual Thing</a>.
+      Compare with <a>Device</a>.</dd>
       <dt>
         <dfn>Servient</dfn>
       </dt>

--- a/index.html
+++ b/index.html
@@ -405,6 +405,11 @@
       </dt>
       <dd>A Thing Description without a user-defined identifier (`id` attribute).</dd>
       <dt>
+        <dfn>Connected Device</dfn>
+      </dt>
+      <dd>
+      A synonym for <a>Device</a>.</dd>
+      <dt>
         <dfn data-lt="WoT Binding Templates">Binding
           Templates</dfn>
       </dt>
@@ -449,6 +454,7 @@
       </dt>
       <dd>A Device is a physical entity that has a network interface.
       Devices can be described by a <a>Thing Description</a> and are a kind of <a>Thing</a>.
+      A synonym for <a>Connected Device</a>.
       Compare with <a>Service</a>.</dd>
       <dt>
         <dfn>Digital Twin</dfn>


### PR DESCRIPTION
New definitions for Device, Service, and Shadow.
Updated definitions for Virtual Thing and Digital Twin.
Resolves issue #709.
Resolves issue #708.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/711.html" title="Last updated on Feb 17, 2022, 5:15 PM UTC (14d0d30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/711/78521c3...mmccool:14d0d30.html" title="Last updated on Feb 17, 2022, 5:15 PM UTC (14d0d30)">Diff</a>