### PR TITLE
Add `data-lt` to a definition of Thing Model

### DIFF
--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
         used as an optional part of the <a>WoT Discovery</a> process.
       </dd>
       <dt>
-        <dfn>Thing Model</dfn>
+        <dfn data-lt="WoT Thing Model">Thing Model</dfn>
       </dt>
       <dd>A <a>Thing Model</a> is a description for a class of Things that have the same 
         capabilities. It describes the <a>Properties</a>, <a>Actions</a>, and <a>Events</a> and common metadata that are 


### PR DESCRIPTION
To resolve the following Respec error, I've added an alternative name to Thing Model definition in "4. Terminology. "

![image](https://user-images.githubusercontent.com/30313213/156711552-3aa7cdf7-8c11-419f-b239-b803b38533a9.png)
