### PR TITLE
Update list of editors

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,18 +36,20 @@
           company: "Fujitsu Ltd.",
           companyURL: "https://www.fujitsu.com/"
         }, {
-          name: "Toru Kawaguchi",
-          w3cid: "79307",
-          company: "Panasonic Corp.",
-          companyURL: "https://www.panasonic.com/"
-        }, {
           name: "Kunihiko Toumura",
           w3cid: "83488",
           company: "Hitachi, Ltd.",
           companyURL: "https://www.hitachi.com/"
-        }, {
+        }],
+      formerEditors: [
+        {
           name: "Kazuo Kajimoto",
-          note: "Former Editor, when at Panasonic"
+          note: "when at Panasonic"
+        }, {
+          name: "Toru Kawaguchi",
+          w3cid: "79307",
+          company: "Panasonic Corp.",
+          companyURL: "https://www.panasonic.com/"
         }],
       otherLinks: [
         {


### PR DESCRIPTION
Fix #719 .

Used ReSpec's [`formerEditors` option](https://github.com/w3c/respec/wiki/formerEditors).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-architecture/pull/720.html" title="Last updated on Mar 11, 2022, 12:30 AM UTC (1490fb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/720/2ceb79e...k-toumura:1490fb1.html" title="Last updated on Mar 11, 2022, 12:30 AM UTC (1490fb1)">Diff</a>