### PR TITLE
Merge "4. Device Categories" section into "3. Terminology" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,10 +816,9 @@
         (which include the supported Protocol Bindings), and links to related Things.
         The WoT Thing Description format is the central building block of W3C WoT.</dd>
     </dl>
-  </section>
 
-  <!-- Device categories -->
-  <section id="device-categoriesdevices" class="informative">
+    <!-- Device categories -->
+    <section id="device-categoriesdevices">
       <h2>Device Categories</h2>	  
       <p>
         In a deployment of WoT conforming to the <a href="https://www.w3.org/TR/wot-architecture/#architecture-abstract">WoT Abstract Architecture</a>
@@ -914,6 +913,7 @@
       For secure communications we consider devices that support TLS/HTTP, DTLS/CoAP, 
       and similar secure protocols.
       </p>
+    </section>
   </section>
 
   <section id="sec-application-domains" class="informative">


### PR DESCRIPTION
Fix #705 .

