### PR TITLE
Additional Security/Privacy Considerations around TLS, access controls for PII

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,8 +499,12 @@
       <dt>
         <dfn data-lt="WoT Discoverer" class="lint-ignore">Discoverer</dfn>
       </dt>
-      <dd>An entity that generates and registers a TD with an exploration service
-        on behalf of a <a>Thing</a> which may not be able to do it for itself.
+      <dd>An entity which acts as a client of a WoT Discovery service to discover 
+        and fetch a <a>Thing Description</a>, 
+        e.g. by being introduced to and searching a 
+        <a>Thing Description Directory</a> exploration service or by
+        fetching a <a>Thing Description</a> directly from 
+        the well-known endpoint on a Thing.
       </dd>
       <dt>
         <dfn>Domain-specific Vocabulary</dfn>
@@ -658,6 +662,14 @@
         It does not include any secret information or concrete data (including public keys), and does
         not by itself, provide access to the Thing. Instead, it describes the mechanisms by which access
         may be obtained by authorized users, including how they must authenticate themselves.
+      </dd>
+      <dt>
+        <dfn data-lt="WoT Registrant" class="lint-ignore">Registrant</dfn>
+      </dt>
+      <dd>An entity which registers a <a>Thing Description</a>
+        with a <a>Thing Description Directory</a>. 
+        This entity may or may not be the <a>Thing</a> that
+        the registered <a>Thing Description</a> describes.
       </dd>
       <dt>
         <dfn>Security</dfn>

--- a/index.html
+++ b/index.html
@@ -4301,6 +4301,81 @@
         </dd>
       </dl>
     </section>
+    <section id="sec-security-consideration-secure-transport">
+      <h2>Secure Transport</h2>
+      <p>
+      As noted in
+      <a href="#sec-security-consideration-trusted-environment-risks"></a>,
+      there are situations in which secure transports, such as TLS, are not
+      feasible or are difficult to set up, such as on a local LAN within a home.
+      Unforunately, generally access control mechanisms in HTTP 
+      are generally designed to be used with secure transport and can be 
+      easily bypassed without it.  In particular, it is relatively easy to
+      capture passwords and tokens from unencrypted protocol interactions
+      which can be intercepted by a third party.  In addition, man-in-the-middle
+      attacks can be easily implemented without TLS providing server authentication. 
+      </p>
+      <dl>
+        <dt>Mitigation:</dt>
+        <dd>
+          <p>
+            Because of the practical difficulties in setting up TLS in all
+            situations, we cannot make a blanket assertion that it is always 
+            required.  Instead we provide a set of requirements for different use
+            cases:
+          </p>
+          <dl>
+          <dt>Public Networks:<dt>
+          <dd><span class="rfc2119-assertion" 
+              id="arch-security-consideration-tls-mandatory">When a Thing is made 
+            available on the public internet so it can
+            be accessed by anyone, from anywhere, then it MUST be protected by secure
+            transport such as TLS or DTLS.
+          </span>
+            A Thing available on the public internet will have a public
+            URL and so normal CA mechanisms to provide certificates are available.
+            This should be done even if there are no access controls on the endpoint,
+            for example when providing a publically accessible service,
+            because secure transport also protects the privacy of requestors
+            (for example, the content of queries).
+          </dd>
+          <dt>Private Networks:<dt>
+          <dd>
+          <dd><span class="rfc2119-assertion" 
+              id="arch-security-consideration-tls-optional-on-lan">
+           Private networks such as a LAN, protected by a firewall, MAY use the 
+           <a href="#sec-security-consideration-trusted-environment-risks">Trusted 
+           Environment</a> approach of depending on network security only</a>.
+           This is not generally recommended but may be necessary for practical
+           reasons.  Please see the referenced security consideration for
+           additional risks and mitigations with this approach. 
+          </dd>
+          <dt>Brownfield Devices:<dt>
+          <dd>WoT is descriptive and an accurate description of existing
+           "brownfield" devices may reveal they are not secure.  
+           For example, a specific
+           device may use HTTP without TLS, which is not secure even if it 
+           uses access controls such as a password.
+           It is often not possible to upgrade such devices to support stronger
+           security.
+           In these cases, the above two mitigations still apply.  If exposed
+           on a private network, the 
+           <a href="#sec-security-consideration-trusted-environment-risks">Trusted 
+           Environment</a> approach should be used, with access limited as much
+           as possible.
+           If it is desired to expose such a device on the public internet,
+           additional steps should be taken the enhance its security.  In particular,
+           a proxy can be used to ensure that communications over the public
+           network use secure transport.  A proxy can also be used to provide
+           access controls.
+          </dd>
+          </dl>
+          <p>Additional considerations apply if a Thing can reveal
+          <a>Personally Identifiable Information</a> (PII).
+          See <a href="#arch-privacy-consideration-access-controls"></a>.
+        </dd>
+      </dl>
+    </section>
   </section>
   <section id="sec-privacy-considerations">
     <h1>Privacy Considerations</h1>
@@ -4406,6 +4481,38 @@
         </dl>
       </section>
     </section>
+    <section id="arch-privacy-consideration-access-controls">
+      <h2>Access to PII</h2>
+      <p>In addition to the risks of revealing PII through metadata
+      discussed in <a href="#sec-security-consideration-td-pii"></a>,
+      the data returned by Things can itself be sensitive.
+      For example, a Thing could be monitoring the location or
+      health of a specific person.  Information associated with a 
+      person should be treated as PII even if it is not immediately
+      obvious that it is sensitive, since it could be combined with
+      other information to reveal sensitive information.
+      </p>
+      <dl>
+        <dt>Mitigation:</dt>
+        <dd>
+	      <span class="rfc2119-assertion" id="arch-privacy-consideration-access-control-mandatory">
+Things returning data associated with a person accessible to anyone other than that person MUST use some form of access control.
+	    </span>
+      Specifically, in this situation, the <code>nosec</code> security
+      scheme described in [[WOT-THING-DESCRIPTION]] cannot be used,
+      as it provides no access control.
+      Again it should be noted that access controls are generally only
+      effective when secure transport is also available;
+      see <a href="#sec-security-consideration-secure-transport"></a>.
+      A special case of this is a <a>Thing Description Directory</a>,
+      as described in [[WOT-DISCOVERY]], which is a Thing that returns 
+      Thing Descriptions as data.  
+      Following the principle that Thing Descriptions describing
+      Things associated with specific persons should be treated as
+      PII, even if they do not explictly contain it, this implies
+      that such directories cannot use <code>nosec</code>.
+        </dd>
+     </dl>
   </section>
 
   <section id="changes" class="appendix">


### PR DESCRIPTION
This is an attempt to address the issue of when and where TLS and access controls are required.  Initial feedback from PING is requesting that we make access controls mandatory when PII is involved, but this is only effective if there is also secure transport, which we can't mandate in a blanket fashion due to limitations on deploying it on a LAN.

In summary, this PR adds the following rules:
- Secure transport (TLS) mandatory for public internet access.  
- Secure transport (TLS) recommended for private networks (e.g. LANs), but optional.
- Access controls mandatory for access to PII by people other than the person the PII is about.  This includes TDs describing Things related to people in directories, but also data from normal Things associated with a person.