### PR TITLE
Remove abnf validation from rel and op

### DIFF
--- a/index.html
+++ b/index.html
@@ -2338,10 +2338,8 @@
           <li>optionally target attributes.</li>
         </ul>
         <p>
-          Link relation types are either a set of predefined tokens that are registered with IANA [[?IANA-RELATIONS]],
-          which must adhere to the ABNF [[!RFC5234]]
-          <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code> (e.g.,
-          <code>stylesheet</code>),
+          Link relation types are either a set of predefined tokens that are registered with IANA [[?IANA-RELATIONS]], 
+          (e.g. <code>stylesheet</code>),
           or extension types in the form of URIs [[!RFC3986]].
           <span class="rfc2119-assertion" id="arch-rel-types">
             Extension relation types MUST be compared as strings using a case-insensitive comparison.
@@ -2415,12 +2413,6 @@
           the operation. Operation types are denoted similar
           to link relation types:</p>
         <ul>
-          <li>
-            <span class="rfc2119-assertion" id="arch-op-wellknown">
-              Well-known operation types MUST follow the ABNF
-              <code style="white-space: nowrap;">LOALPHA *( LOALPHA / DIGIT / "." / "-" )</code>.
-            </span>
-          </li>
           <li>
             <span class="rfc2119-assertion" id="arch-op-extension-uri">
               Extension operation types MUST be URIs [[!RFC3986]] that uniquely identify the type.


### PR DESCRIPTION
Fixes #743 

I have also removed it from the rel keyword


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/749.html" title="Last updated on May 12, 2022, 8:44 AM UTC (367ed01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/749/7be810a...367ed01.html" title="Last updated on May 12, 2022, 8:44 AM UTC (367ed01)">Diff</a>