### PR TITLE
Remove arch-id-correlation assertion

### DIFF
--- a/index.html
+++ b/index.html
@@ -1811,7 +1811,7 @@
         <a>Edge device</a> such as a gateway, or the cloud.
       </p>
       <p>
-        A typical deployment challenge is a scenario, where local networks are not reachable from the Internet,
+        A typical deployment challenge is a scenario where local networks are not reachable from the Internet,
         usually because of IPv4 Network Address Translation (NAT) or firewall devices.
         To remedy this situation, W3C WoT allows for <a>Intermediaries</a> between <a>Things</a> and <a>Consumers</a>.
       </p>
@@ -1825,14 +1825,11 @@
         but which points to the <a>WoT Interface</a> provided by the <a>Intermediary</a>.
         <a>Intermediaries</a> may also augment existing <a>Things</a> with additional capabilities or compose a new
         <a>Thing</a> out of multiple available <a>Things</a>,
-        thereby forming a virtual entity.
-        To <a>Consumers</a>, <a>Intermediaries</a> look like <a>Things</a>, as they possess <a>WoT Thing
-          Descriptions</a> and provide a <a>WoT Interface</a>,
-        and hence might be indistinguishable from <a>Things</a> in a layered system architecture like the Web [[?REST]].
-        <span class="rfc2119-assertion" id="arch-id-correlation">
-          An identifier in the <a>WoT Thing Description</a> MUST allow for the correlation of multiple <a>TDs</a>
-          representing the same original <a>Thing</a> or ultimately unique physical entity.
-        </span>
+        thereby forming a <a>Virtual Thing</a>.
+        To <a>Consumers</a>, <a>Intermediaries</a> are just another kind of <a>Thing</a>, as they possess <a>WoT Thing
+          Descriptions</a> and provide a <a>WoT Interface</a>.
+        They may be indistinguishable from <a>Things</a> directly representing physical devices
+        in a layered system architecture like the Web [[?REST]].
       </p>
       <figure id="intermediary">
         <img src="images/architecture/intermediary.png" srcset="images/architecture/intermediary.svg"


### PR DESCRIPTION
Resolves Issue #635 
Relevant to Issue #625
- delete arch-id-correlation assertion
- adjust text immediately before, which I think was written when we were constraining Things to represent *physical* entities, and implied an Intermediary was not a Thing, but "like" a Thing.  I changed this to say an Intermediary is a "kind of" Thing, and also changed the phrase "virtual entity" to "Virtual Thing" since we have a consistent definition for that now.

ASIDE: the "[big discussion](https://github.com/w3c/wot-discovery/issues/190)" in discovery was actually about whether the ID refers to the TD (as a document) or to the Thing being described by the TD.   In other words, do we identify the map or the territory? If we choose the latter interpretation, AND insist that only physical entities can be Things, it would mean the same ID would end up getting used for Intermediaries pointing at the same physical entity, which would be logical but would cause chaos in other ways (e.g. collisions in directories, being unable to hide ids of things being proxied which you may want to do for privacy reasons, etc).  At the same time, we do tend to reuse the same ID when we subset a TD (for example, limit it to one language after language negotiation) so we can't really say the ID identifies the document, either.  I think the correct interpretation is that the id is in fact the the id of the *Thing*, but that a Thing is an abstraction, and there may in fact be Virtual Things (like Intermediaries) that don't directly map to a physical entity.   This logically means that there could be variant TDs describing the same (Virtual) Thing which we frankly have not quite come to terms with yet in WoT Discovery (trying to register two different TDs with the same id in a directory will cause one to overwrite the other) but for now we are going to have to let it go and deal with this in a later round, and assume a 1:1 mapping between TDs and Things so the same ID can be used for both.  This is one of several reasons I was arguing for using local ids in directories rather than the IDs in the TDs themselves as directory keys; then it would be no problem to register multiple TDs with the same *internal* ID, since they would be assigned different local IDs.  I lost that argument but plan to re-open it in Discovery 2.0.  Part of the issue is the information model for TDs themselves probably needs to resolve this issue first, and fixing that will be a non-backwards-compatible change to the information model.

PS: I know the assertion that was just deleted said the IDs for intermediaries should be correlated, not the same, but since there is no actual normative mechanism to do this, and it conflicts with other assertions about privacy, use of uuids, etc, I still think we should remove it.  It's still possible to use links to indicate in an Intermediary what it is "wrapping".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/768.html" title="Last updated on May 19, 2022, 12:21 PM UTC (916f8ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/768/9316543...mmccool:916f8ce.html" title="Last updated on May 19, 2022, 12:21 PM UTC (916f8ce)">Diff</a>