### PR TITLE
Fix section structure error (6. Cross-domain Collaboration, 7. System Integration)

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,13 +380,6 @@
       <li>a set of common deployment patterns in
         <a href="#sec-common-deployment-patterns"></a>,
       </li>
-      <li>
-        examples for 
-        cross domain collaboration in 
-        <a href="#sec-cross-domain-collaboration"></a>
-        and system integration 
-        <a href="#sec-system-integration"></a>,
-      </li>
       <li>a definition of the abstract architecture in
         <a href="#sec-wot-architecture"></a>,
       </li>
@@ -1567,7 +1560,6 @@
         Examples include <a>Shadows</a> and <a>Digital Twins</a>.
       </p>
     </section>
-    </section>
 
 
     <section id="sec-cross-domain-collaboration">
@@ -1607,7 +1599,7 @@
         such as the devices including the legacy devices,
         controllers, gateways and cloud servers are located at
         physical locations such as inside building, outside
-        buildings, and data centers. <a href="#usecase-overview"></a>
+        buildings, and data centers. <a href="#system-integration"></a>
         is an overview that shows the combinations and
         communication paths of these entities.
       </p>


### PR DESCRIPTION
(related issue/PR: #628, #771)
I didn't notice in on the Arch call in May 24th, some structure of section seems broken.
There is extra `</section>` tag on after "5.9 Virtual Things": https://github.com/w3c/wot-architecture/blob/02b9aeaf3cffe29b72c4522362c9380aca5c2eb3/index.html#L1568-L1571

This extra tag accidentally makes the subsequent "Cross-domain Collaboration" and "System Integration" subsection independent from the Section 5 "Common Deployment Patterns".

This PR remove the extra section tag, and also remove introduction text for "Cross-domain Collaboration" and "System Integration" (and also fix section ID).   The resulting section structure is as follows:
```
  ...
5. Common Deployment Patterns
5.1 Telemetry
  ...
5.9 Virtual Things
5.10 Cross-domain Collaboration
5.11 System Integration
6. Abstract WoT System Architecture
  ...
```

(if the original section structure is intentional, please close this PR)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-architecture/pull/774.html" title="Last updated on May 25, 2022, 12:17 AM UTC (d9b98ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/774/02b9aea...k-toumura:d9b98ea.html" title="Last updated on May 25, 2022, 12:17 AM UTC (d9b98ea)">Diff</a>