### PR TITLE
Specify TLS and DTLS versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4330,10 +4330,10 @@
       there are situations in which secure transports, such as TLS, are not
       feasible or are difficult to set up, such as on a local LAN within a home.
       Unfortunately, generally access control mechanisms in HTTP 
-      are generally designed to be used with secure transport and can be 
+      are designed to be used with secure transport and can be 
       easily bypassed without it.  In particular, it is relatively easy to
       capture passwords and tokens from unencrypted protocol interactions
-      which can be intercepted by a third party.  In addition, man-in-the-middle
+      which can be intercepted by a third party.  Also, man-in-the-middle
       attacks can be easily implemented without TLS providing server authentication. 
       </p>
       <dl>
@@ -4402,6 +4402,30 @@
            access controls.
           </dd>
           </dl>
+          <p>
+          <span class="rfc2119-assertion" 
+              id="arch-security-consideration-tls-1-3">
+            When secure transport over TCP is appropriate,
+            then TLS 1.3 [[RFC8446]]
+            SHOULD be used.</span>
+          <span class="rfc2119-assertion" 
+              id="arch-security-consideration-tls-1-2">
+            If TLS 1.3 cannot be used for compatibility reasons
+            but secure transport over TCP is appropriate,
+            TLS 1.2 [[RFC5246]]
+            MAY be used.</span>
+          <span class="rfc2119-assertion" 
+              id="arch-security-consideration-dtls-1-3">
+            When secure transport over UDP is appropriate,
+            then DTLS 1.3 [[RFC9147]]
+            SHOULD be used.</span>
+          <span class="rfc2119-assertion" 
+              id="arch-security-consideration-dtls-1-2">
+            If DTLS 1.3 cannot be used for compatibility reasons
+            but secure transport over UDP is appropriate,
+            then DTLS 1.2 [[RFC6347]]
+            MAY be used.</span>
+          </p>
           <p>Additional considerations apply if a Thing can reveal
           <a>Personally Identifiable Information</a> (PII).
           See <a href="#arch-privacy-consideration-access-controls"></a>.

--- a/index.html
+++ b/index.html
@@ -4340,7 +4340,7 @@
         <dt>Mitigation:</dt>
         <dd>
           <p>
-            Because of the practical difficulties in setting up TLS in all
+            Because of the practical difficulties in setting up secure transport in all
             situations, we cannot make a blanket assertion that it is always 
             required.  Instead we provide a set of requirements for different use
             cases:

--- a/index.html
+++ b/index.html
@@ -4406,7 +4406,7 @@
           <span class="rfc2119-assertion" 
               id="arch-security-consideration-tls-1-3">
             When secure transport over TCP is appropriate,
-            then TLS 1.3 [[RFC8446]]
+            then at least TLS 1.3 [[RFC8446]]
             SHOULD be used.</span>
           <span class="rfc2119-assertion" 
               id="arch-security-consideration-tls-1-2">
@@ -4417,7 +4417,7 @@
           <span class="rfc2119-assertion" 
               id="arch-security-consideration-dtls-1-3">
             When secure transport over UDP is appropriate,
-            then DTLS 1.3 [[RFC9147]]
+            then at least DTLS 1.3 [[RFC9147]]
             SHOULD be used.</span>
           <span class="rfc2119-assertion" 
               id="arch-security-consideration-dtls-1-2">

--- a/index.html
+++ b/index.html
@@ -4425,6 +4425,14 @@
             but secure transport over UDP is appropriate,
             then DTLS 1.2 [[RFC6347]]
             MAY be used.</span>
+          <span class="rfc2119-assertion"
+              id="arch-security-consideration-no-earlier-tls-or-dtls">
+            Versions of DLTS or TLS earlier than 1.2 MUST NOT be used for 
+            new development.
+          </span>
+          Existing Things using earlier versions of TLS or DTLS can be 
+          described by WoT metadata (e.g. Thing Descriptions) but should
+          be considered insecure.
           </p>
           <p>Additional considerations apply if a Thing can reveal
           <a>Personally Identifiable Information</a> (PII).


### PR DESCRIPTION
Resolves #753 

- remove two generallys
- SHOULD use TLS 1.3
- MAY use TLS 1.2
- SHOULD use DTLS 1.3
- MAY use TLS 1.2
- MUST not use earlier versions of TLS or DTLS for new development (as opposed to describing brownfield devices)
- RFC references for the above


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/783.html" title="Last updated on Jun 30, 2022, 10:01 AM UTC (77a9070)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/783/af14f99...mmccool:77a9070.html" title="Last updated on Jun 30, 2022, 10:01 AM UTC (77a9070)">Diff</a>