### PR TITLE
Address feedback from i18n group

### DIFF
--- a/index.html
+++ b/index.html
@@ -2390,7 +2390,8 @@
           (e.g. <code>stylesheet</code>),
           or extension types in the form of URIs [[!RFC3986]].
           <span class="rfc2119-assertion" id="arch-rel-types">
-            Extension relation types MUST be compared as strings using a case-insensitive comparison.
+            Extension relation types MUST be compared as strings using ASCII case-insensitive comparison,
+            (c.f. <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case insensitive</a>).
             (If they are serialized in a different format they are to be converted to URIs).</span>
           <span class="rfc2119-assertion" id="arch-rel-type-lowercase">
             Nevertheless, all-lowercase URIs SHOULD be used for extension relation types [[!RFC8288]].</span>


### PR DESCRIPTION
adding reference to ASCII case insensitive definition of whatwg.
Resiolves issue #775


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/795.html" title="Last updated on Jul 4, 2022, 8:22 PM UTC (5dc9f94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/795/0b1117c...5dc9f94.html" title="Last updated on Jul 4, 2022, 8:22 PM UTC (5dc9f94)">Diff</a>