### PR TITLE
Add change log from FPWD 1.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -4633,7 +4633,40 @@ Services returning Thing Descriptions with immutable IDs MUST use some form of a
   <section id="changes" class="appendix">
     <h1>Recent Specification Changes</h1>
 
-    <h2 id="changes-from-recommendation-1.0">Changes from the 1.0 version of [[wot-architecture]]</h2>
+    <h2 id="changes-from-fpwd-1.1">Changes from the FPWD version of [[wot-architecture11]]</h2>
+    <ul>
+      <li>Move Toru Kawaguchi to former editors.</li>
+      <li>Update abstract to reflect use of prescription (as opposed to pure description) where necessary.</li>
+      <li>New section under Terminology: Device Categories.</li>
+      <li>Section removed: System Integration.</li>
+      <li>Requirements section removed.</li>
+      <li>References to "WoT Use Cases and Requirements"
+          [[wot-use-cases-requirements]] document updated (note also inclusion of requirements analysis here).</li>
+      <li>Lifecycle section reworked; removal of separate "Information Lifecycle" section.</li>
+      <li>Reference and discuss new WoT building block and document: WoT Discovery [[wot-discovery]]</li>
+      <li>Update discussion of WoT Profiles [[wot-profile]]</li>
+      <li>Update discussion of WoT Binding Templates [[wot-binding-templates]]</li>
+      <li>Rename "System Topologies (Horizontals)" to "Common Deployment Patterns".</li>
+      <li>Rename "Application Domains (Verticals)" to "Application Domains".</li>
+      <li>New or revised deployment patterns:
+        <ul>
+          <li>Telemetry</li>
+          <li>Orchestration</li>
+          <li>Virtual Things</li>
+        </ul>
+      </li>
+      <li>Revise Security Considerations and Privacy Considerations: 
+       <ul>
+          <li>Reorganized to ensure that risks and mitigations are presented separately, 
+          and that normative content is only given under mitigations.</li>
+          <li>Added new section for Access to PII covering actual data access, not just metadata.</li>
+          <li>Added new section for Trusted Environments.</li>
+          <li>Added new section for Secure Transport. This section defines under what
+              conditions (D)TLS should or must be used.</li>
+        </ul>
+    </ul>
+
+    <h2 id="changes-in-fpwd-1.1-from-recommendation-1.0">Changes in the FPWD from the 1.0 version of [[wot-architecture]]</h2>
     <ul>
       <li>Make Security Considerations and Privacy Considerations normative.</li>
       <li>Add definitions for Connected Device (a.k.a. Device), Service, and Shadow.  

--- a/publication/ver11/2-wd/Overview.html
+++ b/publication/ver11/2-wd/Overview.html
@@ -2,9 +2,9 @@
 <html lang="en-US">
 <head>
 <meta name="generator" content=
-"HTML Tidy for HTML5 for Apple macOS version 5.8.0">
+"HTML Tidy for HTML5 for Linux version 5.6.0">
 <meta charset="utf-8">
-<meta name="generator" content="ReSpec 32.2.0">
+<meta name="generator" content="ReSpec 32.2.1">
 <meta name="viewport" content=
 "width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
@@ -154,7 +154,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
-  "datePublished": "2022-07-22",
+  "datePublished": "2022-08-04",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -438,6 +438,75 @@ dd{margin-left:0}
       }
     },
     {
+      "id": "https://www.w3.org/TR/wot-architecture11/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Architecture 1.1",
+      "url": "https://www.w3.org/TR/wot-architecture11/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Toru Kawaguchi"
+        },
+        {
+          "name": "Kunihiko Toumura"
+        },
+        {
+          "name": "Kazuo Kajimoto"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-profile/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Profile",
+      "url": "https://www.w3.org/TR/wot-profile/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Sebastian Käbisch"
+        },
+        {
+          "name": "Tomoaki Mizushima"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-binding-templates/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Binding Templates",
+      "url": "https://www.w3.org/TR/wot-binding-templates/",
+      "creator": [
+        {
+          "name": "Michael Koster"
+        },
+        {
+          "name": "Ege Korkan"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
       "id": "https://www.w3.org/TR/wot-architecture/",
       "type": "TechArticle",
       "name": "Web of Things (WoT) Architecture",
@@ -492,23 +561,6 @@ dd{margin-left:0}
       ],
       "publisher": {
         "name": "IETF"
-      }
-    },
-    {
-      "id": "https://www.w3.org/TR/wot-binding-templates/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Binding Templates",
-      "url": "https://www.w3.org/TR/wot-binding-templates/",
-      "creator": [
-        {
-          "name": "Michael Koster"
-        },
-        {
-          "name": "Ege Korkan"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
       }
     },
     {
@@ -1307,14 +1359,14 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2022-07-22T00:00:00.000Z",
-  "generatedSubtitle": "W3C Working Draft 22 July 2022"
+  "publishISODate": "2022-08-04T00:00:00.000Z",
+  "generatedSubtitle": "W3C Working Draft 04 August 2022"
 }
 </script>
 <link rel="stylesheet" href=
 "https://www.w3.org/StyleSheets/TR/2021/W3C-WD">
 </head>
-<body class="h-entry toc-inline">
+<body class="h-entry">
 <div class="head">
 <p class="logos"><a class="logo" href=
 "https://www.w3.org/"><img crossorigin="" alt="W3C" height="48"
@@ -1324,14 +1376,14 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 1.1</h1>
 <p id="w3c-state"><a href=
 "https://www.w3.org/standards/types#WD">W3C Working Draft</a>
-<time class="dt-published" datetime="2022-07-22">22 July
+<time class="dt-published" datetime="2022-08-04">04 August
 2022</time></p>
-<details open>
+<details open="">
 <summary>More details about this document</summary>
 <dl>
 <dt>This version:</dt>
 <dd><a class="u-url" href=
-"https://www.w3.org/TR/2022/WD-wot-architecture11-20220722/">https://www.w3.org/TR/2022/WD-wot-architecture11-20220722/</a></dd>
+"https://www.w3.org/TR/2022/WD-wot-architecture11-20220804/">https://www.w3.org/TR/2022/WD-wot-architecture11-20220804/</a></dd>
 <dt>Latest published version:</dt>
 <dd><a href=
 "https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a></dd>
@@ -1457,21 +1509,21 @@ Members.</p>
 obsoleted by other documents at any time. It is inappropriate to
 cite this document as other than work in progress.</p>
 <p>This document was produced by a group operating under the
-<a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">1
-August 2017 <abbr title="World Wide Web Consortium">W3C</abbr>
-Patent Policy</a>. <abbr title=
-"World Wide Web Consortium">W3C</abbr> maintains a <a rel=
-"disclosure" href="https://www.w3.org/groups/wg/wot/ipr">public
-list of any patent disclosures</a> made in connection with the
-deliverables of the group; that page also includes instructions for
-disclosing a patent. An individual who has actual knowledge of a
-patent which the individual believes contains <a href=
-"https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">
-Essential Claim(s)</a> must disclose the information in accordance
-with <a href=
-"https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">
-section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr>
-Patent Policy</a>.</p>
+<a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title=
+"World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+<abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+<a rel="disclosure" href=
+"https://www.w3.org/groups/wg/wot/ipr">public list of any patent
+disclosures</a> made in connection with the deliverables of the
+group; that page also includes instructions for disclosing a
+patent. An individual who has actual knowledge of a patent which
+the individual believes contains <a href=
+"https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential
+Claim(s)</a> must disclose the information in accordance with
+<a href=
+"https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section
+6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+Policy</a>.</p>
 <p>This document is governed by the <a id="w3c_process_revision"
 href="https://www.w3.org/2021/Process-20211102/">2 November 2021
 <abbr title="World Wide Web Consortium">W3C</abbr> Process
@@ -1892,9 +1944,14 @@ Information</a></li>
 "secno">A.</bdi> Recent Specification Changes</a>
 <ol class="toc">
 <li class="tocline"><a class="tocxref" href=
-"#changes-from-recommendation-1.0"><bdi class="secno">A.1</bdi>
-Changes from the 1.0 version of [<cite><span class="formerLink"
-data-link-type="biblio" title=
+"#changes-from-fpwd-1.1"><bdi class="secno">A.1</bdi> Changes from
+the FPWD version of [<cite><span class="formerLink" data-link-type=
+"biblio" title=
+"Web of Things (WoT) Architecture 1.1">wot-architecture11</span></cite>]</a></li>
+<li class="tocline"><a class="tocxref" href=
+"#changes-in-fpwd-1.1-from-recommendation-1.0"><bdi class=
+"secno">A.2</bdi> Changes in the FPWD from the 1.0 version of
+[<cite><span class="formerLink" data-link-type="biblio" title=
 "Web of Things (WoT) Architecture">wot-architecture</span></cite>]</a></li>
 </ol>
 </li>
@@ -2375,6 +2432,7 @@ application using it.</dd>
 aria-haspopup="dialog" data-dfn-type="dfn">Producer</dfn></dt>
 <dd>An entity that can create WoT Thing Descriptions for a specific
 Thing.</dd>
+<dt></dt>
 <dt><dfn data-plurals="properties" id="dfn-property" tabindex="0"
 aria-haspopup="dialog" data-dfn-type="dfn">Property</dfn></dt>
 <dd>An Interaction Affordance that exposes state of the Thing. This
@@ -3735,6 +3793,7 @@ manufacturers that share a common <a href="#dfn-thing" class=
 class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-thing-31">Thing</a>.</li>
 </ul>
+<p></p>
 <p>The <a href="#dfn-wot-thing-model" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-wot-thing-model-10">Thing
 Model</a> is a logical description of the interface and possible
@@ -4175,6 +4234,7 @@ lifecycle stages in a <a href="#dfn-thing-description" class=
 <li>Bootstrap and provision a device directly with WoT, in order to
 become operational for WoT.</li>
 </ul>
+<p></p>
 <p>Various provisioning schemes are being used in IoT protocol
 suites. The text in this section is based on <a href=
 "https://github.com/w3c/wot-architecture/tree/master/proposals">proposals</a>
@@ -4211,6 +4271,7 @@ provisioning.</li>
 (e.g. factory reset).</li>
 <li>Decommission and irreversibly destroy a device.</li>
 </ul>
+<p></p>
 <p>Taken into account these provisioning flows, in general a device
 can be in one of the following states:</p>
 <ul>
@@ -4242,6 +4303,7 @@ is relevant for device management purposes. It does not exist in
 OneM2M, LwM2M, OCF, T2TRG and is called <em>End-of-life</em> in
 OPC-UA and Anima.</li>
 </ul>
+<p></p>
 <figure id="fig-device-lifecycle"><img src=
 "images/architecture/device-lifecycle-1.svg" srcset=
 "images/architecture/device-lifecycle-1.svg" class=
@@ -4296,6 +4358,7 @@ factory default state.</li>
 <li><strong>Destroy</strong>: the device is erased from all data,
 software and may be physically destroyed.</li>
 </ul>
+<p></p>
 </section>
 </section>
 <section id="sec-interaction-model">
@@ -5377,6 +5440,7 @@ protocol bindings for the event mechanism:</p>
 These profiles can be used stand alone, or a device can implement a
 combination of them. It is envisioned, that other profiles will be
 defined in the future, that contain mappings to other protocols.
+<p></p>
 <section id="profiling-methodology">
 <div class="header-wrapper">
 <h4 id="profile-description-methodology"><bdi class=
@@ -5457,6 +5521,7 @@ extended profiles can be built on top of a baseline profile.</p>
 "fig-title">WoT Baseline Profile - Other
 Profiles</span></figcaption>
 </figure>
+<p></p>
 </section>
 </section>
 <section id="sec-discovery">
@@ -5542,6 +5607,8 @@ id="ref-for-dfn-wot-introduction-4">Introduction</a> URLs
 e.g. a human-readable device type or name.</span> Randomly
 generated URLs are recommended.</li>
 </ul>
+<p></p>
+<p></p>
 </section>
 <section id="sec-discovery-exploration">
 <div class="header-wrapper">
@@ -7669,6 +7736,7 @@ that it is always required. Instead we provide a set of
 requirements for different use cases:</p>
 <dl>
 <dt>Public Networks:</dt>
+<dt></dt>
 <dd><span class="rfc2119-assertion" id=
 "arch-security-consideration-tls-mandatory-pub">When a Thing is
 made available on the public internet so it can be accessed by
@@ -7681,6 +7749,7 @@ endpoint, for example when providing a publically accessible
 service, because secure transport also protects the privacy of
 requestors (for example, the content of queries).</dd>
 <dt>Private Networks:</dt>
+<dt></dt>
 <dd><span class="rfc2119-assertion" id=
 "arch-security-consideration-tls-recommended-priv">When a Thing is
 made available on a private network then it <em class=
@@ -7702,6 +7771,7 @@ for practical reasons. Please see the referenced security
 consideration for additional risks and mitigations with this
 approach.</dd>
 <dt>Brownfield Devices:</dt>
+<dt></dt>
 <dd>WoT is descriptive and an accurate description of existing
 "brownfield" devices may reveal they are not secure. For example, a
 specific device may use HTTP without TLS, which is not secure even
@@ -7938,14 +8008,76 @@ discourages casual access by unauthorized parties.</dd>
 Recent Specification Changes</h2>
 <a class="self-link" href="#changes" aria-label=
 "Permalink for Appendix A."></a></div>
-<section id="changes-from-the-1-0-version-of-wot-architecture">
+<section id="changes-from-the-fpwd-version-of-wot-architecture11">
 <div class="header-wrapper">
-<h3 id="changes-from-recommendation-1.0"><bdi class=
-"secno">A.1</bdi> Changes from the 1.0 version of [<cite><a class=
-"bibref" data-link-type="biblio" href="#bib-wot-architecture"
-title="Web of Things (WoT) Architecture">wot-architecture</a></cite>]</h3>
-<a class="self-link" href="#changes-from-recommendation-1.0"
-aria-label="Permalink for Appendix A.1"></a></div>
+<h3 id="changes-from-fpwd-1.1"><bdi class="secno">A.1</bdi> Changes
+from the FPWD version of [<cite><a class="bibref" data-link-type=
+"biblio" href="#bib-wot-architecture11" title=
+"Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>]</h3>
+<a class="self-link" href="#changes-from-fpwd-1.1" aria-label=
+"Permalink for Appendix A.1"></a></div>
+<ul>
+<li>Move Toru Kawaguchi to former editors.</li>
+<li>Update abstract to reflect use of prescription (as opposed to
+pure description) where necessary.</li>
+<li>New section under Terminology: Device Categories.</li>
+<li>Section removed: System Integration.</li>
+<li>Requirements section removed.</li>
+<li>References to "WoT Use Cases and Requirements" [<cite><a class=
+"bibref" data-link-type="biblio" href=
+"#bib-wot-use-cases-requirements" title=
+"Web of Things (WoT) Use Cases and Requirements">wot-use-cases-requirements</a></cite>]
+document updated (note also inclusion of requirements analysis
+here).</li>
+<li>Lifecycle section reworked; removal of separate "Information
+Lifecycle" section.</li>
+<li>Reference and discuss new WoT building block and document: WoT
+Discovery [<cite><a class="bibref" data-link-type="biblio" href=
+"#bib-wot-discovery" title=
+"Web of Things (WoT) Discovery">wot-discovery</a></cite>]</li>
+<li>Update discussion of WoT Profiles [<cite><a class="bibref"
+data-link-type="biblio" href="#bib-wot-profile" title=
+"Web of Things (WoT) Profile">wot-profile</a></cite>]</li>
+<li>Update discussion of WoT Binding Templates [<cite><a class=
+"bibref" data-link-type="biblio" href="#bib-wot-binding-templates"
+title=
+"Web of Things (WoT) Binding Templates">wot-binding-templates</a></cite>]</li>
+<li>Rename "System Topologies (Horizontals)" to "Common Deployment
+Patterns".</li>
+<li>Rename "Application Domains (Verticals)" to "Application
+Domains".</li>
+<li>New or revised deployment patterns:
+<ul>
+<li>Telemetry</li>
+<li>Orchestration</li>
+<li>Virtual Things</li>
+</ul>
+</li>
+<li>Revise Security Considerations and Privacy Considerations:
+<ul>
+<li>Reorganized to ensure that risks and mitigations are presented
+separately, and that normative content is only given under
+mitigations.</li>
+<li>Added new section for Access to PII covering actual data
+access, not just metadata.</li>
+<li>Added new section for Trusted Environments.</li>
+<li>Added new section for Secure Transport. This section defines
+under what conditions (D)TLS should or must be used.</li>
+</ul>
+</li>
+</ul>
+</section>
+<section id=
+"changes-in-the-fpwd-from-the-1-0-version-of-wot-architecture">
+<div class="header-wrapper">
+<h3 id="changes-in-fpwd-1.1-from-recommendation-1.0"><bdi class=
+"secno">A.2</bdi> Changes in the FPWD from the 1.0 version of
+[<cite><a class="bibref" data-link-type="biblio" href=
+"#bib-wot-architecture" title=
+"Web of Things (WoT) Architecture">wot-architecture</a></cite>]</h3>
+<a class="self-link" href=
+"#changes-in-fpwd-1.1-from-recommendation-1.0" aria-label=
+"Permalink for Appendix A.2"></a></div>
 <ul>
 <li>Make Security Considerations and Privacy Considerations
 normative.</li>
@@ -8103,12 +8235,30 @@ Things (WoT) Architecture</cite></a>. Matthias Kovatsch; Ryuichi
 Matsukura; Michael Lagally; Toru Kawaguchi; Kunihiko Toumura; Kazuo
 Kajimoto. W3C. 9 April 2020. W3C Recommendation. URL: <a href=
 "https://www.w3.org/TR/wot-architecture/">https://www.w3.org/TR/wot-architecture/</a></dd>
+<dt id="bib-wot-architecture11">[wot-architecture11]</dt>
+<dd><a href="https://www.w3.org/TR/wot-architecture11/"><cite>Web
+of Things (WoT) Architecture 1.1</cite></a>. Michael Lagally;
+Ryuichi Matsukura; Toru Kawaguchi; Kunihiko Toumura; Kazuo
+Kajimoto. W3C. 24 November 2020. W3C Working Draft. URL: <a href=
+"https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a></dd>
+<dt id="bib-wot-binding-templates">[wot-binding-templates]</dt>
+<dd><a href=
+"https://www.w3.org/TR/wot-binding-templates/"><cite>Web of Things
+(WoT) Binding Templates</cite></a>. Michael Koster; Ege Korkan.
+W3C. 30 January 2020. W3C Working Group Note. URL: <a href=
+"https://www.w3.org/TR/wot-binding-templates/">https://www.w3.org/TR/wot-binding-templates/</a></dd>
 <dt id="bib-wot-discovery">[WOT-DISCOVERY]</dt>
 <dd><a href="https://www.w3.org/TR/wot-discovery/"><cite>Web of
 Things (WoT) Discovery</cite></a>. Andrea Cimmino; Michael McCool;
 Farshid Tavakolizadeh; Kunihiko Toumura. W3C. November 2020. URL:
 <a href=
 "https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a></dd>
+<dt id="bib-wot-profile">[wot-profile]</dt>
+<dd><a href="https://www.w3.org/TR/wot-profile/"><cite>Web of
+Things (WoT) Profile</cite></a>. Michael Lagally; Michael McCool;
+Ryuichi Matsukura; Sebastian Käbisch; Tomoaki Mizushima. W3C. 24
+November 2020. W3C Working Draft. URL: <a href=
+"https://www.w3.org/TR/wot-profile/">https://www.w3.org/TR/wot-profile/</a></dd>
 <dt id="bib-wot-security">[WOT-SECURITY]</dt>
 <dd><a href="https://w3c.github.io/wot-security/"><cite>Web of
 Things (WoT) Security and Privacy Guidelines</cite></a>. ; Michael
@@ -8289,12 +8439,6 @@ Sensor Network Ontology</cite></a>. Armin Haller; Krzysztof
 Janowicz; Simon Cox; Danh Le Phuoc; Kerry Taylor; Maxime
 Lefrançois. W3C. 19 October 2017. W3C Recommendation. URL: <a href=
 "https://www.w3.org/TR/vocab-ssn/">https://www.w3.org/TR/vocab-ssn/</a></dd>
-<dt id="bib-wot-binding-templates">[WOT-BINDING-TEMPLATES]</dt>
-<dd><a href=
-"https://www.w3.org/TR/wot-binding-templates/"><cite>Web of Things
-(WoT) Binding Templates</cite></a>. Michael Koster; Ege Korkan.
-W3C. 30 January 2020. W3C Working Group Note. URL: <a href=
-"https://www.w3.org/TR/wot-binding-templates/">https://www.w3.org/TR/wot-binding-templates/</a></dd>
 <dt id="bib-wot-pioneers-1">[WOT-PIONEERS-1]</dt>
 <dd><a href=
 "https://pdfs.semanticscholar.org/3ee3/a2e8ce93fbf9ba14ad54e12adaeb1f3ca392.pdf">
@@ -8348,7 +8492,8 @@ ITU-T. January 2015. Recommendation. URL: <a href=
 "Back to Top">↑</abbr></a></p>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-action" aria-label=
-"Links in this document to definition: Action">
+"Links in this document to definition: Action"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-action" aria-label=
 "Permalink for definition: Action. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -8369,7 +8514,8 @@ Thing Model</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-anonymous-thing-description" aria-label=
-"Links in this document to definition: Anonymous TD">
+"Links in this document to definition: Anonymous TD"><span class=
+"caret"></span>
 <div><a class="self-link" href=
 "#dfn-wot-anonymous-thing-description" aria-label=
 "Permalink for definition: Anonymous TD. Activate to close this dialog.">
@@ -8382,6 +8528,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-connected-device" aria-label=
 "Links in this document to definition: Connected Device">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-connected-device" aria-label=
 "Permalink for definition: Connected Device. Activate to close this dialog.">
 Permalink</a></div>
@@ -8394,6 +8541,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-binding-templates" aria-label=
 "Links in this document to definition: Binding Templates">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-wot-binding-templates"
 aria-label=
 "Permalink for definition: Binding Templates. Activate to close this dialog.">
@@ -8423,7 +8571,8 @@ Thing Description Communication Metadata Risk</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-consumed-thing" aria-label=
-"Links in this document to definition: Consumed Thing">
+"Links in this document to definition: Consumed Thing"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-consumed-thing" aria-label=
 "Permalink for definition: Consumed Thing. Activate to close this dialog.">
 Permalink</a></div>
@@ -8479,7 +8628,8 @@ Acting as a Proxy</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-content-type" aria-label=
-"Links in this document to definition: Content Type">
+"Links in this document to definition: Content Type"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-content-type" aria-label=
 "Permalink for definition: Content Type. Activate to close this dialog.">
 Permalink</a></div>
@@ -8494,6 +8644,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-consuming-a-thing" aria-label=
 "Links in this document to definition: Consuming a Thing">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-consuming-a-thing" aria-label=
 "Permalink for definition: Consuming a Thing. Activate to close this dialog.">
 Permalink</a></div>
@@ -8504,7 +8655,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-consumer" aria-label=
-"Links in this document to definition: Consumer">
+"Links in this document to definition: Consumer"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-consumer" aria-label=
 "Permalink for definition: Consumer. Activate to close this dialog.">
 Permalink</a></div>
@@ -8643,7 +8795,8 @@ Synchronization</a> <a href="#ref-for-dfn-consumer-80" title=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-data-schema" aria-label=
-"Links in this document to definition: Data Schema">
+"Links in this document to definition: Data Schema"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-data-schema" aria-label=
 "Permalink for definition: Data Schema. Activate to close this dialog.">
 Permalink</a></div>
@@ -8661,7 +8814,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-device" aria-label=
-"Links in this document to definition: Device">
+"Links in this document to definition: Device"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-device" aria-label=
 "Permalink for definition: Device. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -8673,7 +8827,8 @@ Terminology</a> <a href="#ref-for-dfn-device-2" title=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-digital-twin" aria-label=
-"Links in this document to definition: Digital Twin">
+"Links in this document to definition: Digital Twin"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-digital-twin" aria-label=
 "Permalink for definition: Digital Twin. Activate to close this dialog.">
 Permalink</a></div>
@@ -8699,7 +8854,8 @@ Intermediary Acting as a Digital Twin</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-discovery" aria-label=
-"Links in this document to definition: Discovery">
+"Links in this document to definition: Discovery"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-discovery" aria-label=
 "Permalink for definition: Discovery. Activate to close this dialog.">
 Permalink</a></div>
@@ -8741,7 +8897,8 @@ Risk</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-discoverer" aria-label=
-"Links in this document to definition: Discoverer">
+"Links in this document to definition: Discoverer"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-discoverer" aria-label=
 "Permalink for definition: Discoverer. Activate to close this dialog.">
 Permalink</a></div>
@@ -8753,6 +8910,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-domain-specific-vocabulary" aria-label=
 "Links in this document to definition: Domain-specific Vocabulary">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-domain-specific-vocabulary"
 aria-label=
 "Permalink for definition: Domain-specific Vocabulary. Activate to close this dialog.">
@@ -8769,7 +8927,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-edge-device" aria-label=
-"Links in this document to definition: Edge Device">
+"Links in this document to definition: Edge Device"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-edge-device" aria-label=
 "Permalink for definition: Edge Device. Activate to close this dialog.">
 Permalink</a></div>
@@ -8781,7 +8940,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-enriched-thing-description" aria-label=
-"Links in this document to definition: Enriched TD">
+"Links in this document to definition: Enriched TD"><span class=
+"caret"></span>
 <div><a class="self-link" href=
 "#dfn-wot-enriched-thing-description" aria-label=
 "Permalink for definition: Enriched TD. Activate to close this dialog.">
@@ -8793,7 +8953,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-event" aria-label=
-"Links in this document to definition: Event">
+"Links in this document to definition: Event"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-event" aria-label=
 "Permalink for definition: Event. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -8817,7 +8978,8 @@ Intermediary Acting as a Digital Twin</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-exploration" aria-label=
-"Links in this document to definition: Exploration">
+"Links in this document to definition: Exploration"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-exploration" aria-label=
 "Permalink for definition: Exploration. Activate to close this dialog.">
 Permalink</a></div>
@@ -8834,7 +8996,8 @@ title="Reference 3">(3)</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-exposed-thing" aria-label=
-"Links in this document to definition: Exposed Thing">
+"Links in this document to definition: Exposed Thing"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-exposed-thing" aria-label=
 "Permalink for definition: Exposed Thing. Activate to close this dialog.">
 Permalink</a></div>
@@ -8891,6 +9054,7 @@ Service</a> <a href="#ref-for-dfn-exposed-thing-23" title=
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-exposing-a-thing" aria-label=
 "Links in this document to definition: Exposing a Thing">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-exposing-a-thing" aria-label=
 "Permalink for definition: Exposing a Thing. Activate to close this dialog.">
 Permalink</a></div>
@@ -8902,6 +9066,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-hypermedia-control" aria-label=
 "Links in this document to definition: Hypermedia Control">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-hypermedia-control"
 aria-label="Permalink for definition: Hypermedia Control. Activate to close this dialog.">
 Permalink</a></div>
@@ -8927,6 +9092,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-interaction-affordance" aria-label=
 "Links in this document to definition: Interaction Affordance">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-interaction-affordance"
 aria-label=
 "Permalink for definition: Interaction Affordance. Activate to close this dialog.">
@@ -9000,6 +9166,7 @@ Service</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-interaction-model" aria-label=
 "Links in this document to definition: Interaction Model">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-interaction-model" aria-label=
 "Permalink for definition: Interaction Model. Activate to close this dialog.">
 Permalink</a></div>
@@ -9015,7 +9182,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-intermediary" aria-label=
-"Links in this document to definition: Intermediary">
+"Links in this document to definition: Intermediary"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-intermediary" aria-label=
 "Permalink for definition: Intermediary. Activate to close this dialog.">
 Permalink</a></div>
@@ -9137,7 +9305,8 @@ Connection Through Proxy Synchronization</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-introduction" aria-label=
-"Links in this document to definition: Introduction">
+"Links in this document to definition: Introduction"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-introduction" aria-label=
 "Permalink for definition: Introduction. Activate to close this dialog.">
 Permalink</a></div>
@@ -9154,7 +9323,8 @@ title="Reference 3">(3)</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-iot-platform" aria-label=
-"Links in this document to definition: IoT Platform">
+"Links in this document to definition: IoT Platform"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-iot-platform" aria-label=
 "Permalink for definition: IoT Platform. Activate to close this dialog.">
 Permalink</a></div>
@@ -9181,7 +9351,8 @@ Thing Description Communication Metadata Risk</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-metadata" aria-label=
-"Links in this document to definition: Metadata">
+"Links in this document to definition: Metadata"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-metadata" aria-label=
 "Permalink for definition: Metadata. Activate to close this dialog.">
 Permalink</a></div>
@@ -9194,6 +9365,7 @@ Permalink</a></div>
 id="dfn-panel-for-dfn-personally-identifiable-information"
 aria-label=
 "Links in this document to definition: Personally Identifiable Information (PII)">
+<span class="caret"></span>
 <div><a class="self-link" href=
 "#dfn-personally-identifiable-information" aria-label=
 "Permalink for definition: Personally Identifiable Information (PII). Activate to close this dialog.">
@@ -9221,7 +9393,8 @@ Access to Personally Identifiable Information</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-orchestration" aria-label=
-"Links in this document to definition: Orchestration">
+"Links in this document to definition: Orchestration"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-orchestration" aria-label=
 "Permalink for definition: Orchestration. Activate to close this dialog.">
 Permalink</a></div>
@@ -9232,7 +9405,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-partial-td" aria-label=
-"Links in this document to definition: Partial TD">
+"Links in this document to definition: Partial TD"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-partial-td" aria-label=
 "Permalink for definition: Partial TD. Activate to close this dialog.">
 Permalink</a></div>
@@ -9245,7 +9419,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-privacy" aria-label=
-"Links in this document to definition: Privacy">
+"Links in this document to definition: Privacy"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-privacy" aria-label=
 "Permalink for definition: Privacy. Activate to close this dialog.">
 Permalink</a></div>
@@ -9257,6 +9432,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-private-security-data" aria-label=
 "Links in this document to definition: Private Security Data">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-private-security-data"
 aria-label=
 "Permalink for definition: Private Security Data. Activate to close this dialog.">
@@ -9283,7 +9459,8 @@ Thing Description Private Security Data Risk</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-producer" aria-label=
-"Links in this document to definition: Producer">
+"Links in this document to definition: Producer"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-producer" aria-label=
 "Permalink for definition: Producer. Activate to close this dialog.">
 Permalink</a></div>
@@ -9297,7 +9474,8 @@ Thing Description Private Security Data Risk</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-property" aria-label=
-"Links in this document to definition: Property">
+"Links in this document to definition: Property"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-property" aria-label=
 "Permalink for definition: Property. Activate to close this dialog.">
 Permalink</a></div>
@@ -9320,6 +9498,7 @@ Terminology</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-protocol-binding" aria-label=
 "Links in this document to definition: Protocol Binding">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-wot-protocol-binding"
 aria-label=
 "Permalink for definition: Protocol Binding. Activate to close this dialog.">
@@ -9362,6 +9541,7 @@ Discovery Using a Thing Description Directory</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-public-security-metadata" aria-label=
 "Links in this document to definition: Public Security Metadata">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-public-security-metadata"
 aria-label=
 "Permalink for definition: Public Security Metadata. Activate to close this dialog.">
@@ -9392,7 +9572,8 @@ Thing Description Private Security Data Risk</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-registrant" aria-label=
-"Links in this document to definition: Registrant">
+"Links in this document to definition: Registrant"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-registrant" aria-label=
 "Permalink for definition: Registrant. Activate to close this dialog.">
 Permalink</a></div>
@@ -9403,7 +9584,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-security" aria-label=
-"Links in this document to definition: Security">
+"Links in this document to definition: Security"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-security" aria-label=
 "Permalink for definition: Security. Activate to close this dialog.">
 Permalink</a></div>
@@ -9416,6 +9598,7 @@ Terminology</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-security-configuration" aria-label=
 "Links in this document to definition: Security Configuration">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-security-configuration"
 aria-label=
 "Permalink for definition: Security Configuration. Activate to close this dialog.">
@@ -9434,7 +9617,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-service" aria-label=
-"Links in this document to definition: Service">
+"Links in this document to definition: Service"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-service" aria-label=
 "Permalink for definition: Service. Activate to close this dialog.">
 Permalink</a></div>
@@ -9449,7 +9633,8 @@ Terminology</a> <a href="#ref-for-dfn-service-2" title=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-servient" aria-label=
-"Links in this document to definition: Servient">
+"Links in this document to definition: Servient"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-servient" aria-label=
 "Permalink for definition: Servient. Activate to close this dialog.">
 Permalink</a></div>
@@ -9527,7 +9712,8 @@ Risks</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-shadow" aria-label=
-"Links in this document to definition: Shadow">
+"Links in this document to definition: Shadow"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-shadow" aria-label=
 "Permalink for definition: Shadow. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -9542,7 +9728,8 @@ Terminology</a> <a href="#ref-for-dfn-shadow-2" title=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-subprotocol" aria-label=
-"Links in this document to definition: Subprotocol">
+"Links in this document to definition: Subprotocol"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-subprotocol" aria-label=
 "Permalink for definition: Subprotocol. Activate to close this dialog.">
 Permalink</a></div>
@@ -9556,7 +9743,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-td" aria-label=
-"Links in this document to definition: TD">
+"Links in this document to definition: TD"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-td" aria-label=
 "Permalink for definition: TD. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -9616,7 +9804,8 @@ Thing Description Private Security Data Risk</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-tdd" aria-label=
-"Links in this document to definition: TDD">
+"Links in this document to definition: TDD"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-tdd" aria-label=
 "Permalink for definition: TDD. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -9633,7 +9822,8 @@ id="dfn-panel-for-dfn-tdd" aria-label=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-td-vocabulary" aria-label=
-"Links in this document to definition: TD Vocabulary">
+"Links in this document to definition: TD Vocabulary"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-td-vocabulary" aria-label=
 "Permalink for definition: TD Vocabulary. Activate to close this dialog.">
 Permalink</a></div>
@@ -9645,6 +9835,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-td-context-extension" aria-label=
 "Links in this document to definition: TD Context Extension">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-td-context-extension"
 aria-label=
 "Permalink for definition: TD Context Extension. Activate to close this dialog.">
@@ -9656,7 +9847,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-td-server" aria-label=
-"Links in this document to definition: TD Server">
+"Links in this document to definition: TD Server"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-td-server" aria-label=
 "Permalink for definition: TD Server. Activate to close this dialog.">
 Permalink</a></div>
@@ -9667,7 +9859,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-thing" aria-label=
-"Links in this document to definition: Thing">
+"Links in this document to definition: Thing"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-thing" aria-label=
 "Permalink for definition: Thing. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -9907,7 +10100,8 @@ Connection Through Proxy Synchronization</a> <a href=
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-web-thing" aria-label=
-"Links in this document to definition: Web Thing">
+"Links in this document to definition: Web Thing"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-web-thing" aria-label=
 "Permalink for definition: Web Thing. Activate to close this dialog.">
 Permalink</a></div>
@@ -9923,6 +10117,7 @@ Architecture</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-thing-description-directory" aria-label=
 "Links in this document to definition: Thing Description Directory">
+<span class="caret"></span>
 <div><a class="self-link" href=
 "#dfn-wot-thing-description-directory" aria-label=
 "Permalink for definition: Thing Description Directory. Activate to close this dialog.">
@@ -9980,6 +10175,7 @@ Access to Personally Identifiable Information</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-thing-description-server" aria-label=
 "Links in this document to definition: Thing Description Server">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-wot-thing-description-server"
 aria-label=
 "Permalink for definition: Thing Description Server. Activate to close this dialog.">
@@ -9992,7 +10188,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-thing-model" aria-label=
-"Links in this document to definition: Thing Model">
+"Links in this document to definition: Thing Model"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-thing-model" aria-label=
 "Permalink for definition: Thing Model. Activate to close this dialog.">
 Permalink</a></div>
@@ -10029,7 +10226,8 @@ title="Reference 4">(4)</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-td-fragment" aria-label=
-"Links in this document to definition: TD Fragment">
+"Links in this document to definition: TD Fragment"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-td-fragment" aria-label=
 "Permalink for definition: TD Fragment. Activate to close this dialog.">
 Permalink</a></div>
@@ -10042,6 +10240,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-transport-protocol" aria-label=
 "Links in this document to definition: Transport Protocol">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-transport-protocol"
 aria-label="Permalink for definition: Transport Protocol. Activate to close this dialog.">
 Permalink</a></div>
@@ -10062,6 +10261,7 @@ title="Reference 3">(3)</a> <a href=
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-trusted-environment" aria-label=
 "Links in this document to definition: Trusted Environment">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-trusted-environment"
 aria-label=
 "Permalink for definition: Trusted Environment. Activate to close this dialog.">
@@ -10080,7 +10280,8 @@ title="Reference 3">(3)</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-virtual-thing" aria-label=
-"Links in this document to definition: Virtual Thing">
+"Links in this document to definition: Virtual Thing"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-virtual-thing" aria-label=
 "Permalink for definition: Virtual Thing. Activate to close this dialog.">
 Permalink</a></div>
@@ -10099,7 +10300,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-vocabulary" aria-label=
-"Links in this document to definition: Vocabulary">
+"Links in this document to definition: Vocabulary"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-vocabulary" aria-label=
 "Permalink for definition: Vocabulary. Activate to close this dialog.">
 Permalink</a></div>
@@ -10111,7 +10313,8 @@ Permalink</a></div>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-term" aria-label=
-"Links in this document to definition: Term">
+"Links in this document to definition: Term"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-term" aria-label=
 "Permalink for definition: Term. Activate to close this dialog.">Permalink</a></div>
 <p><b>Referenced in:</b></p>
@@ -10123,6 +10326,7 @@ Terminology</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-vocabulary-term" aria-label=
 "Links in this document to definition: Vocabulary Term">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-vocabulary-term" aria-label=
 "Permalink for definition: Vocabulary Term. Activate to close this dialog.">
 Permalink</a></div>
@@ -10138,7 +10342,8 @@ title="Reference 4">(4)</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-interface" aria-label=
-"Links in this document to definition: WoT Interface">
+"Links in this document to definition: WoT Interface"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-interface" aria-label=
 "Permalink for definition: WoT Interface. Activate to close this dialog.">
 Permalink</a></div>
@@ -10171,7 +10376,8 @@ Alternative Servient and WoT Implementations</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-runtime" aria-label=
-"Links in this document to definition: WoT Runtime">
+"Links in this document to definition: WoT Runtime"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-runtime" aria-label=
 "Permalink for definition: WoT Runtime. Activate to close this dialog.">
 Permalink</a></div>
@@ -10252,6 +10458,7 @@ title="Reference 4">(4)</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-scripting-api" aria-label=
 "Links in this document to definition: WoT Scripting API">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-wot-scripting-api" aria-label=
 "Permalink for definition: WoT Scripting API. Activate to close this dialog.">
 Permalink</a></div>
@@ -10313,7 +10520,8 @@ title="Reference 3">(3)</a></li>
 </div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-servient" aria-label=
-"Links in this document to definition: WoT Servient">
+"Links in this document to definition: WoT Servient"><span class=
+"caret"></span>
 <div><a class="self-link" href="#dfn-wot-servient" aria-label=
 "Permalink for definition: WoT Servient. Activate to close this dialog.">
 Permalink</a></div>
@@ -10325,6 +10533,7 @@ Permalink</a></div>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-wot-thing-description" aria-label=
 "Links in this document to definition: WoT Thing Description">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-wot-thing-description"
 aria-label=
 "Permalink for definition: WoT Thing Description. Activate to close this dialog.">
@@ -10386,6 +10595,7 @@ Risks</a></li>
 <div class="dfn-panel" hidden="" role="dialog" aria-modal="true"
 id="dfn-panel-for-dfn-thing-description" aria-label=
 "Links in this document to definition: Thing Description">
+<span class="caret"></span>
 <div><a class="self-link" href="#dfn-thing-description" aria-label=
 "Permalink for definition: Thing Description. Activate to close this dialog.">
 Permalink</a></div>

--- a/publication/ver11/2-wd/index.html
+++ b/publication/ver11/2-wd/index.html
@@ -4568,7 +4568,40 @@ Services returning Thing Descriptions with immutable IDs MUST use some form of a
   <section id="changes" class="appendix">
     <h1>Recent Specification Changes</h1>
 
-    <h2 id="changes-from-recommendation-1.0">Changes from the 1.0 version of [[wot-architecture]]</h2>
+    <h2 id="changes-from-fpwd-1.1">Changes from the FPWD version of [[wot-architecture11]]</h2>
+    <ul>
+      <li>Move Toru Kawaguchi to former editors.</li>
+      <li>Update abstract to reflect use of prescription (as opposed to pure description) where necessary.</li>
+      <li>New section under Terminology: Device Categories.</li>
+      <li>Section removed: System Integration.</li>
+      <li>Requirements section removed.</li>
+      <li>References to "WoT Use Cases and Requirements"
+          [[wot-use-cases-requirements]] document updated (note also inclusion of requirements analysis here).</li>
+      <li>Lifecycle section reworked; removal of separate "Information Lifecycle" section.</li>
+      <li>Reference and discuss new WoT building block and document: WoT Discovery [[wot-discovery]]</li>
+      <li>Update discussion of WoT Profiles [[wot-profile]]</li>
+      <li>Update discussion of WoT Binding Templates [[wot-binding-templates]]</li>
+      <li>Rename "System Topologies (Horizontals)" to "Common Deployment Patterns".</li>
+      <li>Rename "Application Domains (Verticals)" to "Application Domains".</li>
+      <li>New or revised deployment patterns:
+        <ul>
+          <li>Telemetry</li>
+          <li>Orchestration</li>
+          <li>Virtual Things</li>
+        </ul>
+      </li>
+      <li>Revise Security Considerations and Privacy Considerations: 
+       <ul>
+          <li>Reorganized to ensure that risks and mitigations are presented separately, 
+          and that normative content is only given under mitigations.</li>
+          <li>Added new section for Access to PII covering actual data access, not just metadata.</li>
+          <li>Added new section for Trusted Environments.</li>
+          <li>Added new section for Secure Transport. This section defines under what
+              conditions (D)TLS should or must be used.</li>
+        </ul>
+    </ul>
+
+    <h2 id="changes-in-fpwd-1.1-from-recommendation-1.0">Changes in the FPWD from the 1.0 version of [[wot-architecture]]</h2>
     <ul>
       <li>Make Security Considerations and Privacy Considerations normative.</li>
       <li>Add definitions for Connected Device (a.k.a. Device), Service, and Shadow.  

--- a/publication/ver11/2-wd/static.html
+++ b/publication/ver11/2-wd/static.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
-<meta name="generator" content="ReSpec 32.2.0">
+<meta name="generator" content="ReSpec 32.2.1">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
 .issue-label{text-transform:initial}
@@ -156,7 +156,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
-  "datePublished": "2022-07-22",
+  "datePublished": "2022-08-04",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -440,6 +440,75 @@ dd{margin-left:0}
       }
     },
     {
+      "id": "https://www.w3.org/TR/wot-architecture11/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Architecture 1.1",
+      "url": "https://www.w3.org/TR/wot-architecture11/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Toru Kawaguchi"
+        },
+        {
+          "name": "Kunihiko Toumura"
+        },
+        {
+          "name": "Kazuo Kajimoto"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-profile/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Profile",
+      "url": "https://www.w3.org/TR/wot-profile/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Sebastian Käbisch"
+        },
+        {
+          "name": "Tomoaki Mizushima"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-binding-templates/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Binding Templates",
+      "url": "https://www.w3.org/TR/wot-binding-templates/",
+      "creator": [
+        {
+          "name": "Michael Koster"
+        },
+        {
+          "name": "Ege Korkan"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
       "id": "https://www.w3.org/TR/wot-architecture/",
       "type": "TechArticle",
       "name": "Web of Things (WoT) Architecture",
@@ -494,23 +563,6 @@ dd{margin-left:0}
       ],
       "publisher": {
         "name": "IETF"
-      }
-    },
-    {
-      "id": "https://www.w3.org/TR/wot-binding-templates/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Binding Templates",
-      "url": "https://www.w3.org/TR/wot-binding-templates/",
-      "creator": [
-        {
-          "name": "Michael Koster"
-        },
-        {
-          "name": "Ege Korkan"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
       }
     },
     {
@@ -1306,21 +1358,21 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2022-07-22T00:00:00.000Z",
-  "generatedSubtitle": "W3C Working Draft 22 July 2022"
+  "publishISODate": "2022-08-04T00:00:00.000Z",
+  "generatedSubtitle": "W3C Working Draft 04 August 2022"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD"></head>
 
-<body class="h-entry toc-inline"><div class="head">
+<body class="h-entry"><div class="head">
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Architecture 1.1</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#WD">W3C Working Draft</a> <time class="dt-published" datetime="2022-07-22">22 July 2022</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#WD">W3C Working Draft</a> <time class="dt-published" datetime="2022-08-04">04 August 2022</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2022/WD-wot-architecture11-20220722/">https://www.w3.org/TR/2022/WD-wot-architecture11-20220722/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2022/WD-wot-architecture11-20220804/">https://www.w3.org/TR/2022/WD-wot-architecture11-20220804/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>
@@ -1434,7 +1486,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     
         This document was produced by a group
         operating under the
-        <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">1 August 2017 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+        <a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
           Policy</a>.
       
     
@@ -1444,9 +1496,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
           the group; that page also includes
           instructions for disclosing a patent. An individual who has actual
           knowledge of a patent which the individual believes contains
-          <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a>
+          <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
           must disclose the information in accordance with
-          <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+          <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
         
   </p><p>
                   This document is governed by the
@@ -1456,7 +1508,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         and Construction</a></li><li class="tocline"><a class="tocxref" href="#agriculture"><bdi class="secno">4.8 </bdi>Agriculture</a></li><li class="tocline"><a class="tocxref" href="#healthcare"><bdi class="secno">4.9 </bdi>Healthcare</a></li><li class="tocline"><a class="tocxref" href="#environmentmonitoring"><bdi class="secno">4.10 </bdi>Environment
         Monitoring</a></li><li class="tocline"><a class="tocxref" href="#smartcities"><bdi class="secno">4.11 </bdi>Smart Cities</a></li><li class="tocline"><a class="tocxref" href="#smartbuildings"><bdi class="secno">4.12 </bdi>Smart Buildings</a></li><li class="tocline"><a class="tocxref" href="#connectedcar"><bdi class="secno">4.13 </bdi>Connected Car</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#connectedcar-example"><bdi class="secno">4.13.1 </bdi>Connected Car
           Example</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-common-deployment-patterns"><bdi class="secno">5. </bdi>Common Deployment Patterns</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#telemetry"><bdi class="secno">5.1 </bdi>Telemetry</a></li><li class="tocline"><a class="tocxref" href="#device-controllers"><bdi class="secno">5.2 </bdi>Device Controllers</a></li><li class="tocline"><a class="tocxref" href="#thing-to-thing"><bdi class="secno">5.3 </bdi>Thing-to-Thing</a></li><li class="tocline"><a class="tocxref" href="#remote-access"><bdi class="secno">5.4 </bdi>Remote Access</a></li><li class="tocline"><a class="tocxref" href="#smart-home-gateways"><bdi class="secno">5.5 </bdi>Smart Home Gateways</a></li><li class="tocline"><a class="tocxref" href="#edge-devices"><bdi class="secno">5.6 </bdi>Edge Devices</a></li><li class="tocline"><a class="tocxref" href="#digital-twins"><bdi class="secno">5.7 </bdi>Digital Twins</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#cloud-ready-devices"><bdi class="secno">5.7.1 </bdi>Cloud-ready Devices</a></li><li class="tocline"><a class="tocxref" href="#orchestration"><bdi class="secno">5.7.2 </bdi>Orchestration</a></li><li class="tocline"><a class="tocxref" href="#legacy-devices"><bdi class="secno">5.7.3 </bdi>Legacy Devices</a></li></ol></li><li class="tocline"><a class="tocxref" href="#multi-cloud"><bdi class="secno">5.8 </bdi>Multi-Cloud</a></li><li class="tocline"><a class="tocxref" href="#virtual-thing"><bdi class="secno">5.9 </bdi>Virtual Things</a></li><li class="tocline"><a class="tocxref" href="#sec-cross-domain-collaboration"><bdi class="secno">5.10 </bdi>Cross-domain Collaboration</a></li><li class="tocline"><a class="tocxref" href="#sec-system-integration"><bdi class="secno">5.11 </bdi>System Integration</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-wot-architecture"><bdi class="secno">6. </bdi>Abstract WoT System Architecture</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-architecture-overview"><bdi class="secno">6.1 </bdi>System Concepts</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#metadata"><bdi class="secno">6.1.1 </bdi>Metadata</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#metadata-thing-descriptions"><bdi class="secno">6.1.1.1 </bdi>Thing Descriptions</a></li><li class="tocline"><a class="tocxref" href="#metadata-thing-models"><bdi class="secno">6.1.1.2 </bdi>Thing Models</a></li></ol></li><li class="tocline"><a class="tocxref" href="#links"><bdi class="secno">6.1.2 </bdi>Links</a></li><li class="tocline"><a class="tocxref" href="#intermediaries"><bdi class="secno">6.1.3 </bdi>Intermediaries</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-affordances"><bdi class="secno">6.2 </bdi>Affordances</a></li><li class="tocline"><a class="tocxref" href="#sec-web-thing"><bdi class="secno">6.3 </bdi>Web Thing</a></li><li class="tocline"><a class="tocxref" href="#lifecycle"><bdi class="secno">6.4 </bdi>Lifecycle</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#simple-system-lifecycle"><bdi class="secno">6.4.1 </bdi>Simple System Lifecycle</a></li><li class="tocline"><a class="tocxref" href="#system-lifecycle-no-directory"><bdi class="secno">6.4.2 </bdi>System Lifecycle with Registration</a></li><li class="tocline"><a class="tocxref" href="#thing-lifecycle"><bdi class="secno">6.4.3 </bdi>Thing Lifecycle</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-interaction-model"><bdi class="secno">6.5 </bdi>Interaction Model</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#properties"><bdi class="secno">6.5.1 </bdi>Properties</a></li><li class="tocline"><a class="tocxref" href="#actions"><bdi class="secno">6.5.2 </bdi>Actions</a></li><li class="tocline"><a class="tocxref" href="#events"><bdi class="secno">6.5.3 </bdi>Events</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-hypermedia-controls"><bdi class="secno">6.6 </bdi>Hypermedia Controls</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-hypermedia-links"><bdi class="secno">6.6.1 </bdi>Links</a></li><li class="tocline"><a class="tocxref" href="#sec-hypermedia-forms"><bdi class="secno">6.6.2 </bdi>Forms</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-protocol-bindings"><bdi class="secno">6.7 </bdi>Protocol Bindings</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#hypermedia-driven"><bdi class="secno">6.7.1 </bdi>Hypermedia-driven</a></li><li class="tocline"><a class="tocxref" href="#sec-arch-URIs"><bdi class="secno">6.7.2 </bdi>URIs</a></li></ol></li><li class="tocline"><a class="tocxref" href="#media-types"><bdi class="secno">6.8 </bdi>Media Types</a></li><li class="tocline"><a class="tocxref" href="#sec-wot-servient-architecture-high-level"><bdi class="secno">6.9 </bdi>WoT System Components and their Interconnectivity</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#direct-communication"><bdi class="secno">6.9.1 </bdi>Direct Communication</a></li><li class="tocline"><a class="tocxref" href="#indirect-communication"><bdi class="secno">6.9.2 </bdi>Indirect Communication</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-building-blocks"><bdi class="secno">7. </bdi>WoT Building Blocks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-thing-description"><bdi class="secno">7.1 </bdi>WoT Thing Description</a></li><li class="tocline"><a class="tocxref" href="#sec-thing-model"><bdi class="secno">7.2 </bdi>Thing Model</a></li><li class="tocline"><a class="tocxref" href="#wot-profiles"><bdi class="secno">7.3 </bdi>Profiles</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#profile-description-methodology"><bdi class="secno">7.3.1 </bdi>Profiling Methodology</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-discovery"><bdi class="secno">7.4 </bdi>WoT Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-discovery-introductions"><bdi class="secno">7.4.1 </bdi>Introduction Mechanisms</a></li><li class="tocline"><a class="tocxref" href="#sec-discovery-exploration"><bdi class="secno">7.4.2 </bdi>Exploration Mechanisms</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-binding-templates"><bdi class="secno">7.5 </bdi>WoT Binding Templates</a></li><li class="tocline"><a class="tocxref" href="#sec-scripting-api"><bdi class="secno">7.6 </bdi>WoT Scripting API</a></li><li class="tocline"><a class="tocxref" href="#sec-security-guidelines"><bdi class="secno">7.7 </bdi>WoT Security and Privacy Guidelines</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-servient-implementation"><bdi class="secno">8. </bdi>Abstract Servient Architecture</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#behavior-implementation"><bdi class="secno">8.1 </bdi>Behavior Implementation</a></li><li class="tocline"><a class="tocxref" href="#wot-runtime"><bdi class="secno">8.2 </bdi>WoT Runtime</a></li><li class="tocline"><a class="tocxref" href="#wot-scripting-api"><bdi class="secno">8.3 </bdi>WoT Scripting API</a></li><li class="tocline"><a class="tocxref" href="#exposed-thing-and-consumed-thing-abstractions"><bdi class="secno">8.4 </bdi>Exposed Thing and Consumed Thing Abstractions</a></li><li class="tocline"><a class="tocxref" href="#private-security-data"><bdi class="secno">8.5 </bdi>Private Security Data</a></li><li class="tocline"><a class="tocxref" href="#protocol-stack-implementation"><bdi class="secno">8.6 </bdi>Protocol Stack Implementation</a></li><li class="tocline"><a class="tocxref" href="#system-api"><bdi class="secno">8.7 </bdi>System API</a></li><li class="tocline"><a class="tocxref" href="#alt-servient-impl"><bdi class="secno">8.8 </bdi>Alternative Servient and WoT Implementations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#native-impl"><bdi class="secno">8.8.1 </bdi>Native WoT API</a></li><li class="tocline"><a class="tocxref" href="#existing-impl"><bdi class="secno">8.8.2 </bdi>Thing Description for Existing Devices</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-deployment-scenario"><bdi class="secno">9. </bdi>Example WoT Deployments</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-client-server-roles"><bdi class="secno">9.1 </bdi>Thing and Consumer Roles</a></li><li class="tocline"><a class="tocxref" href="#sec-topologies-deployment-scenarios"><bdi class="secno">9.2 </bdi>Topology of WoT Systems and Deployment Scenarios</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-deployment-app-dev"><bdi class="secno">9.2.1 </bdi>Consumer and Thing on the Same Network</a></li><li class="tocline"><a class="tocxref" href="#sec-deployment-intermediaries"><bdi class="secno">9.2.2 </bdi>Consumer and Thing Connected via Intermediaries</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-deployment-app-proxy-dev"><bdi class="secno">9.2.2.1 </bdi>Intermediary Acting as a Proxy</a></li><li class="tocline"><a class="tocxref" href="#sec-deployment-digital-twin"><bdi class="secno">9.2.2.2 </bdi>Intermediary Acting as a Digital Twin</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-deployment-cloud"><bdi class="secno">9.2.3 </bdi>Devices in a Local Network Controlled from a Cloud Service</a></li><li class="tocline"><a class="tocxref" href="#sec-deployment-discovery-with-directory"><bdi class="secno">9.2.4 </bdi>Discovery Using a Thing Description Directory</a></li><li class="tocline"><a class="tocxref" href="#sec-deployment-service-to-service"><bdi class="secno">9.2.5 </bdi>Service-to-Service Connections Across Multiple Domains</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-deployment-service-to-service-synchronized"><bdi class="secno">9.2.5.1 </bdi>Connection Through Thing Description Directory Synchronization</a></li><li class="tocline"><a class="tocxref" href="#sec-deployment-service-sync-proxy"><bdi class="secno">9.2.5.2 </bdi>Connection Through Proxy Synchronization</a></li></ol></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-security-considerations"><bdi class="secno">10. </bdi>Security Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-security-consideration-td-risks"><bdi class="secno">10.1 </bdi>WoT Thing Description Risks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-security-consideration-td-private"><bdi class="secno">10.1.1 </bdi>Thing Description Private Security Data Risk</a></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-td-cm"><bdi class="secno">10.1.2 </bdi>Thing Description Communication Metadata Risk</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-scripting-risks"><bdi class="secno">10.2 </bdi>WoT Scripting API Risks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-security-consideration-cross-script"><bdi class="secno">10.2.1 </bdi>Cross-Script Security Risk</a></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-device-direct-access"><bdi class="secno">10.2.2 </bdi>Physical Device Direct Access Risk</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-runtime-risks"><bdi class="secno">10.3 </bdi>WoT Runtime Risks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-security-consideration-update-provisioning"><bdi class="secno">10.3.1 </bdi>Provisioning and Update Security Risk</a></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-credentials-storage"><bdi class="secno">10.3.2 </bdi>Security Credentials Storage Risk</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-trusted-environment-risks"><bdi class="secno">10.4 </bdi>Trusted Environment Risks</a></li><li class="tocline"><a class="tocxref" href="#sec-security-consideration-secure-transport"><bdi class="secno">10.5 </bdi>Secure Transport</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec-privacy-considerations"><bdi class="secno">11. </bdi>Privacy Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-privacy-consideration-td-risks"><bdi class="secno">11.1 </bdi>WoT Thing Description Risks</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#sec-privacy-consideration-td-pii"><bdi class="secno">11.1.1 </bdi>Thing Description Personally Identifiable
-          Information Risk</a></li></ol></li><li class="tocline"><a class="tocxref" href="#arch-privacy-consideration-access-controls"><bdi class="secno">11.2 </bdi>Access to Personally Identifiable Information</a></li></ol></li><li class="tocline"><a class="tocxref" href="#changes"><bdi class="secno">A. </bdi>Recent Specification Changes</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#changes-from-recommendation-1.0"><bdi class="secno">A.1 </bdi>Changes from the 1.0 version of [<cite><span class="formerLink" data-link-type="biblio" title="Web of Things (WoT) Architecture">wot-architecture</span></cite>]</a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>Acknowledgments</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+          Information Risk</a></li></ol></li><li class="tocline"><a class="tocxref" href="#arch-privacy-consideration-access-controls"><bdi class="secno">11.2 </bdi>Access to Personally Identifiable Information</a></li></ol></li><li class="tocline"><a class="tocxref" href="#changes"><bdi class="secno">A. </bdi>Recent Specification Changes</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#changes-from-fpwd-1.1"><bdi class="secno">A.1 </bdi>Changes from the FPWD version of [<cite><span class="formerLink" data-link-type="biblio" title="Web of Things (WoT) Architecture 1.1">wot-architecture11</span></cite>]</a></li><li class="tocline"><a class="tocxref" href="#changes-in-fpwd-1.1-from-recommendation-1.0"><bdi class="secno">A.2 </bdi>Changes in the FPWD from the 1.0 version of [<cite><span class="formerLink" data-link-type="biblio" title="Web of Things (WoT) Architecture">wot-architecture</span></cite>]</a></li></ol></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>Acknowledgments</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2 </bdi>Informative references</a></li></ol></li></ol></nav>
   <section id="introduction" class="informative"><div class="header-wrapper"><h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
     
     <p>The goals of the <em>Web of Things</em> (WoT) are to improve the interoperability
@@ -5653,7 +5705,40 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">MUS
   <section id="changes" class="appendix"><div class="header-wrapper"><h2 id="a-recent-specification-changes"><bdi class="secno">A. </bdi>Recent Specification Changes</h2><a class="self-link" href="#changes" aria-label="Permalink for Appendix A."></a></div>
     
 
-    <section id="changes-from-the-1-0-version-of-wot-architecture"><div class="header-wrapper"><h3 id="changes-from-recommendation-1.0"><bdi class="secno">A.1 </bdi>Changes from the 1.0 version of [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">wot-architecture</a></cite>]</h3><a class="self-link" href="#changes-from-recommendation-1.0" aria-label="Permalink for Appendix A.1"></a></div>
+    <section id="changes-from-the-fpwd-version-of-wot-architecture11"><div class="header-wrapper"><h3 id="changes-from-fpwd-1.1"><bdi class="secno">A.1 </bdi>Changes from the FPWD version of [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture11" title="Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>]</h3><a class="self-link" href="#changes-from-fpwd-1.1" aria-label="Permalink for Appendix A.1"></a></div>
+    <ul>
+      <li>Move Toru Kawaguchi to former editors.</li>
+      <li>Update abstract to reflect use of prescription (as opposed to pure description) where necessary.</li>
+      <li>New section under Terminology: Device Categories.</li>
+      <li>Section removed: System Integration.</li>
+      <li>Requirements section removed.</li>
+      <li>References to "WoT Use Cases and Requirements"
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-use-cases-requirements" title="Web of Things (WoT) Use Cases and Requirements">wot-use-cases-requirements</a></cite>] document updated (note also inclusion of requirements analysis here).</li>
+      <li>Lifecycle section reworked; removal of separate "Information Lifecycle" section.</li>
+      <li>Reference and discuss new WoT building block and document: WoT Discovery [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">wot-discovery</a></cite>]</li>
+      <li>Update discussion of WoT Profiles [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-profile" title="Web of Things (WoT) Profile">wot-profile</a></cite>]</li>
+      <li>Update discussion of WoT Binding Templates [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">wot-binding-templates</a></cite>]</li>
+      <li>Rename "System Topologies (Horizontals)" to "Common Deployment Patterns".</li>
+      <li>Rename "Application Domains (Verticals)" to "Application Domains".</li>
+      <li>New or revised deployment patterns:
+        <ul>
+          <li>Telemetry</li>
+          <li>Orchestration</li>
+          <li>Virtual Things</li>
+        </ul>
+      </li>
+      <li>Revise Security Considerations and Privacy Considerations: 
+       <ul>
+          <li>Reorganized to ensure that risks and mitigations are presented separately, 
+          and that normative content is only given under mitigations.</li>
+          <li>Added new section for Access to PII covering actual data access, not just metadata.</li>
+          <li>Added new section for Trusted Environments.</li>
+          <li>Added new section for Secure Transport. This section defines under what
+              conditions (D)TLS should or must be used.</li>
+        </ul>
+    </li></ul>
+
+    </section><section id="changes-in-the-fpwd-from-the-1-0-version-of-wot-architecture"><div class="header-wrapper"><h3 id="changes-in-fpwd-1.1-from-recommendation-1.0"><bdi class="secno">A.2 </bdi>Changes in the FPWD from the 1.0 version of [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">wot-architecture</a></cite>]</h3><a class="self-link" href="#changes-in-fpwd-1.1-from-recommendation-1.0" aria-label="Permalink for Appendix A.2"></a></div>
     <ul>
       <li>Make Security Considerations and Privacy Considerations normative.</li>
       <li>Add definitions for Connected Device (a.k.a. Device), Service, and Shadow.  
@@ -5735,8 +5820,14 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">MUS
       <a href="https://solidproject.org/TR/"><cite>Solid Technical Reports</cite></a>.  W3C Solid CG. April 2021. URL: <a href="https://solidproject.org/TR/">https://solidproject.org/TR/</a>
     </dd><dt id="bib-wot-architecture">[wot-architecture]</dt><dd>
       <a href="https://www.w3.org/TR/wot-architecture/"><cite>Web of Things (WoT) Architecture</cite></a>. Matthias Kovatsch; Ryuichi Matsukura; Michael Lagally; Toru Kawaguchi; Kunihiko Toumura; Kazuo Kajimoto.  W3C. 9 April 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/wot-architecture/">https://www.w3.org/TR/wot-architecture/</a>
+    </dd><dt id="bib-wot-architecture11">[wot-architecture11]</dt><dd>
+      <a href="https://www.w3.org/TR/wot-architecture11/"><cite>Web of Things (WoT) Architecture 1.1</cite></a>. Michael Lagally; Ryuichi Matsukura; Toru Kawaguchi; Kunihiko Toumura; Kazuo Kajimoto.  W3C. 24 November 2020. W3C Working Draft. URL: <a href="https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>
+    </dd><dt id="bib-wot-binding-templates">[wot-binding-templates]</dt><dd>
+      <a href="https://www.w3.org/TR/wot-binding-templates/"><cite>Web of Things (WoT) Binding Templates</cite></a>. Michael Koster; Ege Korkan.  W3C. 30 January 2020. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wot-binding-templates/">https://www.w3.org/TR/wot-binding-templates/</a>
     </dd><dt id="bib-wot-discovery">[WOT-DISCOVERY]</dt><dd>
       <a href="https://www.w3.org/TR/wot-discovery/"><cite>Web of Things (WoT) Discovery</cite></a>. Andrea Cimmino; Michael McCool; Farshid Tavakolizadeh; Kunihiko Toumura.  W3C. November 2020. URL: <a href="https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a>
+    </dd><dt id="bib-wot-profile">[wot-profile]</dt><dd>
+      <a href="https://www.w3.org/TR/wot-profile/"><cite>Web of Things (WoT) Profile</cite></a>. Michael Lagally; Michael McCool; Ryuichi Matsukura; Sebastian Käbisch; Tomoaki Mizushima.  W3C. 24 November 2020. W3C Working Draft. URL: <a href="https://www.w3.org/TR/wot-profile/">https://www.w3.org/TR/wot-profile/</a>
     </dd><dt id="bib-wot-security">[WOT-SECURITY]</dt><dd>
       <a href="https://w3c.github.io/wot-security/"><cite>Web of Things (WoT) Security and Privacy Guidelines</cite></a>. ; Michael McCool; Elena Reshetova.  W3C. March 2019. URL: <a href="https://w3c.github.io/wot-security/">https://w3c.github.io/wot-security/</a>
     </dd><dt id="bib-wot-thing-description">[WOT-THING-DESCRIPTION]</dt><dd>
@@ -5798,8 +5889,6 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">MUS
       <a href="https://sites.google.com/site/smartappliancesproject/ontologies/reference-ontology"><cite>Smart Appliances REFerence (SAREF) ontology</cite></a>.  ETSI. November 2015. URL: <a href="https://sites.google.com/site/smartappliancesproject/ontologies/reference-ontology">https://sites.google.com/site/smartappliancesproject/ontologies/reference-ontology</a>
     </dd><dt id="bib-vocab-ssn">[VOCAB-SSN]</dt><dd>
       <a href="https://www.w3.org/TR/vocab-ssn/"><cite>Semantic Sensor Network Ontology</cite></a>. Armin Haller; Krzysztof Janowicz; Simon Cox; Danh Le Phuoc; Kerry Taylor; Maxime Lefrançois.  W3C. 19 October 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/vocab-ssn/">https://www.w3.org/TR/vocab-ssn/</a>
-    </dd><dt id="bib-wot-binding-templates">[WOT-BINDING-TEMPLATES]</dt><dd>
-      <a href="https://www.w3.org/TR/wot-binding-templates/"><cite>Web of Things (WoT) Binding Templates</cite></a>. Michael Koster; Ege Korkan.  W3C. 30 January 2020. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wot-binding-templates/">https://www.w3.org/TR/wot-binding-templates/</a>
     </dd><dt id="bib-wot-pioneers-1">[WOT-PIONEERS-1]</dt><dd>
       <a href="https://pdfs.semanticscholar.org/3ee3/a2e8ce93fbf9ba14ad54e12adaeb1f3ca392.pdf"><cite>Mobile Service Interaction with the Web of Things</cite></a>. E. Rukzio, M. Paolucci; M. Wagner, H. Berndt; J. Hamard; A. Schmidt.  Proceedings of 13th International Conference on Telecommunications (ICT 2006), Funchal, Madeira island, Portugal. May 2006. URL: <a href="https://pdfs.semanticscholar.org/3ee3/a2e8ce93fbf9ba14ad54e12adaeb1f3ca392.pdf">https://pdfs.semanticscholar.org/3ee3/a2e8ce93fbf9ba14ad54e12adaeb1f3ca392.pdf</a>
     </dd><dt id="bib-wot-pioneers-2">[WOT-PIONEERS-2]</dt><dd>


### PR DESCRIPTION
Add a change log for the update from 1-wd (the 1.1 FPWD) to 2-wd.  Derived from diff and by comparing the previous publication with the draft of 2-wd.

Resolves issue #812.

Note: the old change log is still there, from the 1.0 rec to 1-wd, in a separate section.  In the final 1.1 rec we can merge these together into one change log from 1.0 to 1.1.

Note: as with PR #822 there were some HTML issues and changes due to respec version updating, but I did not try to address the HTML issues since addressed in PR #822.  There should not be any merge conflicts, these PRs touch different things.  This PR only touches the change log, changes elsewhere (e.g. due to ReSpec exports) should be consistent.