### PR TITLE
remove arch-security-consideration-public-metadata-only; redundant

### DIFF
--- a/index.html
+++ b/index.html
@@ -4104,10 +4104,6 @@
 	  <span class="rfc2119-assertion" id="arch-security-consideration-separate-security-data">
           There SHOULD be a strict separation of
           <a>Public Security Metadata</a> and <a>Private Security Data</a>.</span>
-	  <span class="rfc2119-assertion" id="arch-security-consideration-public-metadata-only">
-	  <a>Producers</a> of TDs and extensions meant to be used in TDs
-          MUST ensure that only <a>Public Security Metadata</a>
-          is ever stored in TDs.</span>
 	  <span class="rfc2119-assertion" id="arch-security-consideration-auth-private-data">
 	  Authentication and authorization 
 	  SHOULD be established based on separately managed <a>Private Security Data</a>.</span>


### PR DESCRIPTION
resolves #824 

- remove arch-security-consideration-public-metadata-only; redundant.  Could have removed either assertion about public or private metadata, but assertion about not including private metadata is more important.  Also reordered assertions in this section.
