### PR TITLE
restoring changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -4576,7 +4576,37 @@ Services returning Thing Descriptions with immutable IDs MUST use some form of a
   <section id="changes" class="appendix">
     <h1>Recent Specification Changes</h1>
 
-    <h2 id="changes-from-recommendation-1.0">Changes from the 1.0 version of [[wot-architecture]]</h2>
+    <h2 id="changes-from-fpwd-1.1">Changes from the FPWD version</h2>
+    <ul>
+      <li>Move Toru Kawaguchi to former editors.</li>
+      <li>Update abstract to reflect use of prescription (as opposed to pure description) where necessary.</li>
+      <li>New section under Terminology: Device Categories.</li>
+      <li>Section removed: System Integration.</li>
+      <li>Lifecycle section reworked; removal of separate "Information Lifecycle" section.</li>
+      <li>Reference and discuss new WoT building block and document: WoT Discovery [[WOT-DISCOVERY]]</li>
+      <li>Update discussion of WoT Profiles [[WOT-PROFILE]]</li>
+      <li>Update discussion of WoT Binding Templates [[WOT-BINDING-TEMPLATES]]</li>
+      <li>Rename "System Topologies (Horizontals)" to "Common Deployment Patterns".</li>
+      <li>Rename "Application Domains (Verticals)" to "Application Domains".</li>
+      <li>New or revised deployment patterns:
+        <ul>
+          <li>Telemetry</li>
+          <li>Orchestration</li>
+          <li>Virtual Things</li>
+        </ul>
+      </li>
+      <li>Revise Security Considerations and Privacy Considerations: 
+       <ul>
+          <li>Reorganized to ensure that risks and mitigations are presented separately, 
+          and that normative content is only given under mitigations.</li>
+          <li>Added new section for Access to PII covering actual data access, not just metadata.</li>
+          <li>Added new section for Trusted Environments.</li>
+          <li>Added new section for Secure Transport. This section defines under what
+              conditions (D)TLS should or must be used.</li>
+        </ul>
+    </ul>
+
+    <h2 id="changes-in-fpwd-1.1-from-recommendation-1.0">Changes in the FPWD from the 1.0 version of [[wot-architecture]]</h2>
     <ul>
       <li>Make Security Considerations and Privacy Considerations normative.</li>
       <li>Add definitions for Connected Device (a.k.a. Device), Service, and Shadow.  


### PR DESCRIPTION
The changelog has been already published in the latest WD and unfortunately was not merged to the main branch.

https://www.w3.org/TR/2022/WD-wot-architecture11-20220907/#changes

This PR restores it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/832.html" title="Last updated on Sep 8, 2022, 2:52 PM UTC (c61671a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/832/2d1f901...c61671a.html" title="Last updated on Sep 8, 2022, 2:52 PM UTC (c61671a)">Diff</a>