### PR TITLE
Add 2 references to the published use case document - Resolves #802

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
       architecture for the W3C Web of Things.
       This abstract architecture is based on 
       requirements that were derived from use cases for
-      multiple application domains.
+      multiple application domains ([?WOT-USE-CASES-REQUIREMENTS]]).
       Several modular building blocks were identified whose detailed
       specifications are given in other documents.
       This document describes how these building blocks are related and work together.
@@ -1018,6 +1018,8 @@
       targeted by the W3C WoT and which are used to derive the
       abstract architecture discussed in <a href="#sec-building-blocks"></a>.
     </p>
+    <p>These application domains are motivated by the use cases 
+      that are described in [?WOT-USE-CASES-REQUIREMENTS]].</p>
     <p>The Web of Things architecture does not put any
       limitations on use cases and application domains. Various
       application domains have been considered to collect common
@@ -1026,7 +1028,6 @@
     <p>The following sections are not exhaustive. Rather they
       serve as illustrations, where connected things can provide
       additional benefit or enable new scenarios.</p>
-
 
     <section id="consumer-use-cases">
       <h3>Consumer</h3>

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
           date: "April 2019"
         },
         "WOT-USE-CASES-REQUIREMENTS": {
-          href: "https://w3c.github.io/wot-usecases/",
+          href: "https://www.w3.org/TR/wot-usecases/",
           title: "Web of Things (WoT) Use Cases and Requirements",
           publisher: "W3C",
           authors: ["Michael Lagally", "Michael McCool", "Ryuichi Matsukura", "Tomoaki Mizushima"],


### PR DESCRIPTION
Adding 2 references to the published use case document.

Resolves issue #802


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/840.html" title="Last updated on Sep 22, 2022, 9:58 AM UTC (0fd32c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/840/df6692c...0fd32c8.html" title="Last updated on Sep 22, 2022, 9:58 AM UTC (0fd32c8)">Diff</a>