### PR TITLE
Option 2: Define whole Chapter 7 non-normative

### DIFF
--- a/index.html
+++ b/index.html
@@ -2802,11 +2802,9 @@
     </section>
   </section>
 
-  <section id="sec-building-blocks">
+  <section id="sec-building-blocks" class="informative">
     <h1>WoT Building Blocks</h1>
-    <p>
-      <em>This section is normative.</em>
-    </p>
+
     <p> The Web of Things (WoT) building blocks allow the
       implementation of systems that conform with the abstract WoT
       Architecture. The specifics of these building blocks are
@@ -3178,7 +3176,7 @@
 
     <!-- Binding Templates -->
 
-    <section id="sec-binding-templates" class="informative">
+    <section id="sec-binding-templates" >
       <h3>WoT Binding Templates</h3>
 
 
@@ -3285,7 +3283,7 @@
 
     <!-- Scripting -->
 
-    <section id="sec-scripting-api" class="informative">
+    <section id="sec-scripting-api">
       <h3>WoT Scripting API</h3>
       <p> The <a>WoT Scripting API</a> is an optional "convenience"
         building block of W3C WoT that eases IoT application


### PR DESCRIPTION
this is an alternative PR to #862

Since there are no normative assertions in this chapter, there is no reason to define the whole section as normative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/871.html" title="Last updated on Nov 2, 2022, 10:54 AM UTC (41f89d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/871/8cdbb9e...41f89d7.html" title="Last updated on Nov 2, 2022, 10:54 AM UTC (41f89d7)">Diff</a>