### PR TITLE
Update CR and Norm/Inf for section 7

### DIFF
--- a/index.html
+++ b/index.html
@@ -2802,7 +2802,7 @@
     </section>
   </section>
 
-  <section id="sec-building-blocks" class="informative">
+  <section id="sec-building-blocks">
     <h1>WoT Building Blocks</h1>
 
     <p> The Web of Things (WoT) building blocks allow the
@@ -2849,7 +2849,7 @@
       be considered an additional building block.
     </p>
 
-    <section id="sec-thing-description">
+    <section id="sec-thing-description" class="informative">
       <h2>WoT Thing Description</h2>
       <p> The <a>WoT Thing Description</a> (TD) specification
         [[?WOT-THING-DESCRIPTION]] defines an <em>information model</em>
@@ -2912,7 +2912,7 @@
 
 
 
-    <section id="sec-thing-model">
+    <section id="sec-thing-model" class="informative">
       <h2>Thing Model</h2>
 
       <p>The <a>Thing Model</a> defines a template-based model for
@@ -2932,10 +2932,10 @@
 
     </section>
 
-    <section id="wot-profiles">
+    <section id="wot-profiles" class="informative">
       <h3>Profiles</h3>
       <p>
-      The <a>WoT Profile</a> Specification [[!WOT-PROFILE]] defines Profiles, 
+      The <a>WoT Profile</a> Specification [[WOT-PROFILE]] defines Profiles, 
       that enable <em>out of the box interoperability</em> among things 
       and devices. Out of the box interoperability implies, 
       that devices can be integrated into various application 
@@ -3176,7 +3176,7 @@
 
     <!-- Binding Templates -->
 
-    <section id="sec-binding-templates" >
+    <section id="sec-binding-templates">
       <h3>WoT Binding Templates</h3>
 
 
@@ -3283,7 +3283,7 @@
 
     <!-- Scripting -->
 
-    <section id="sec-scripting-api">
+    <section id="sec-scripting-api" class="informative">
       <h3>WoT Scripting API</h3>
       <p> The <a>WoT Scripting API</a> is an optional "convenience"
         building block of W3C WoT that eases IoT application
@@ -3324,7 +3324,7 @@
 
     <!-- Security Guidelines -->
 
-    <section id="sec-security-guidelines">
+    <section id="sec-security-guidelines" class="informative">
       <h3>WoT Security and Privacy Guidelines</h3>
       <p> Security is a cross-cutting concern and should be
         considered in all aspects of system design. In the WoT

--- a/publication/ver11/3-cr/Overview.html
+++ b/publication/ver11/3-cr/Overview.html
@@ -421,32 +421,6 @@ dd{margin-left:0}
       }
     },
     {
-      "id": "https://www.w3.org/TR/wot-profile/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Profile",
-      "url": "https://www.w3.org/TR/wot-profile/",
-      "creator": [
-        {
-          "name": "Michael Lagally"
-        },
-        {
-          "name": "Michael McCool"
-        },
-        {
-          "name": "Ryuichi Matsukura"
-        },
-        {
-          "name": "Sebastian Käbisch"
-        },
-        {
-          "name": "Tomoaki Mizushima"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
-      }
-    },
-    {
       "id": "https://www.w3.org/TR/wot-discovery/",
       "type": "TechArticle",
       "name": "Web of Things (WoT) Discovery",
@@ -535,6 +509,32 @@ dd{margin-left:0}
       ],
       "publisher": {
         "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-profile/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Profile",
+      "url": "https://www.w3.org/TR/wot-profile/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Sebastian Käbisch"
+        },
+        {
+          "name": "Tomoaki Mizushima"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
       }
     },
     {
@@ -5513,7 +5513,6 @@ protocols.</span></p>
 Building Blocks</h2>
 <a class="self-link" href="#sec-building-blocks" aria-label=
 "Permalink for Section 7."></a></div>
-<p><em>This section is normative.</em></p>
 <p>The Web of Things (WoT) building blocks allow the implementation
 of systems that conform with the abstract WoT Architecture. The
 specifics of these building blocks are defined in separate
@@ -5580,12 +5579,13 @@ on each WoT building block: the <a href=
 <a href="#sec-scripting-api">WoT Scripting API</a>. Security,
 although it is a cross-cutting concern, can be considered an
 additional building block.</p>
-<section id="sec-thing-description">
+<section id="sec-thing-description" class="informative">
 <div class="header-wrapper">
 <h3 id="x7-1-wot-thing-description"><bdi class="secno">7.1</bdi>
 WoT Thing Description</h3>
 <a class="self-link" href="#sec-thing-description" aria-label=
 "Permalink for Section 7.1"></a></div>
+<p><em>This section is non-normative.</em></p>
 <p>The <a href="#dfn-wot-thing-description" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-wot-thing-description-12">WoT
 Thing Description</a> (TD) specification [<cite><a class="bibref"
@@ -5690,12 +5690,13 @@ devices with specialized protocols, sleeping devices, etc.) in
 which having a separate service providing the TD is more
 suitable.</p>
 </section>
-<section id="sec-thing-model">
+<section id="sec-thing-model" class="informative">
 <div class="header-wrapper">
 <h3 id="x7-2-thing-model"><bdi class="secno">7.2</bdi> Thing
 Model</h3>
 <a class="self-link" href="#sec-thing-model" aria-label=
 "Permalink for Section 7.2"></a></div>
+<p><em>This section is non-normative.</em></p>
 <p>The <a href="#dfn-wot-thing-model" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-wot-thing-model-19">Thing
 Model</a> defines a template-based model for <a href=
@@ -5732,11 +5733,12 @@ cloud services, or to simulate <a href="#dfn-device" class=
 "ref-for-dfn-device-5">Devices</a> that have not yet been
 developed.</p>
 </section>
-<section id="wot-profiles">
+<section id="wot-profiles" class="informative">
 <div class="header-wrapper">
 <h3 id="x7-3-profiles"><bdi class="secno">7.3</bdi> Profiles</h3>
 <a class="self-link" href="#wot-profiles" aria-label=
 "Permalink for Section 7.3"></a></div>
+<p><em>This section is non-normative.</em></p>
 <p>The <a href="#dfn-wot-profile" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-wot-profile-1">WoT Profile</a>
 Specification [<cite><a class="bibref" data-link-type="biblio"
@@ -6038,13 +6040,12 @@ defined in [<cite><a class="bibref" data-link-type="biblio" href=
 "#dfn-td" class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-td-23">TDs</a>.</span></p>
 </section>
-<section id="sec-binding-templates" class="informative">
+<section id="sec-binding-templates">
 <div class="header-wrapper">
 <h3 id="x7-5-wot-binding-templates"><bdi class="secno">7.5</bdi>
 WoT Binding Templates</h3>
 <a class="self-link" href="#sec-binding-templates" aria-label=
 "Permalink for Section 7.5"></a></div>
-<p><em>This section is non-normative.</em></p>
 <p>The IoT uses a variety of protocols for accessing devices, since
 no single protocol is appropriate in all contexts. Thus, a central
 challenge for the Web of Things is to enable interactions with the
@@ -6293,12 +6294,13 @@ and publish a <a href="#dfn-thing-description" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-thing-description-31">Thing
 Description</a>.</p>
 </section>
-<section id="sec-security-guidelines">
+<section id="sec-security-guidelines" class="informative">
 <div class="header-wrapper">
 <h3 id="x7-7-wot-security-and-privacy-guidelines"><bdi class=
 "secno">7.7</bdi> WoT Security and Privacy Guidelines</h3>
 <a class="self-link" href="#sec-security-guidelines" aria-label=
 "Permalink for Section 7.7"></a></div>
+<p><em>This section is non-normative.</em></p>
 <p>Security is a cross-cutting concern and should be considered in
 all aspects of system design. In the WoT architecture, security is
 supported by certain explicit features, such as support for

--- a/publication/ver11/3-cr/index.html
+++ b/publication/ver11/3-cr/index.html
@@ -2909,9 +2909,6 @@
 
   <section id="sec-building-blocks">
     <h1>WoT Building Blocks</h1>
-    <p>
-      <em>This section is normative.</em>
-    </p>
     <p> The Web of Things (WoT) building blocks allow the
       implementation of systems that conform with the abstract WoT
       Architecture. The specifics of these building blocks are
@@ -2956,7 +2953,7 @@
       be considered an additional building block.
     </p>
 
-    <section id="sec-thing-description">
+    <section id="sec-thing-description" class="informative">
       <h2>WoT Thing Description</h2>
       <p> The <a>WoT Thing Description</a> (TD) specification
         [[?WOT-THING-DESCRIPTION]] defines an <em>information model</em>
@@ -3019,7 +3016,7 @@
 
 
 
-    <section id="sec-thing-model">
+    <section id="sec-thing-model" class="informative">
       <h2>Thing Model</h2>
 
       <p>The <a>Thing Model</a> defines a template-based model for
@@ -3039,10 +3036,10 @@
 
     </section>
 
-    <section id="wot-profiles">
+    <section id="wot-profiles" class="informative">
       <h3>Profiles</h3>
       <p>
-      The <a>WoT Profile</a> Specification [[!WOT-PROFILE]] defines Profiles, 
+      The <a>WoT Profile</a> Specification [[?WOT-PROFILE]] defines Profiles, 
       that enable <em>out of the box interoperability</em> among things 
       and devices. Out of the box interoperability implies, 
       that devices can be integrated into various application 
@@ -3283,7 +3280,7 @@
 
     <!-- Binding Templates -->
 
-    <section id="sec-binding-templates" class="informative">
+    <section id="sec-binding-templates">
       <h3>WoT Binding Templates</h3>
 
 
@@ -3431,7 +3428,7 @@
 
     <!-- Security Guidelines -->
 
-    <section id="sec-security-guidelines">
+    <section id="sec-security-guidelines" class="informative">
       <h3>WoT Security and Privacy Guidelines</h3>
       <p> Security is a cross-cutting concern and should be
         considered in all aspects of system design. In the WoT

--- a/publication/ver11/3-cr/static.html
+++ b/publication/ver11/3-cr/static.html
@@ -423,32 +423,6 @@ dd{margin-left:0}
       }
     },
     {
-      "id": "https://www.w3.org/TR/wot-profile/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Profile",
-      "url": "https://www.w3.org/TR/wot-profile/",
-      "creator": [
-        {
-          "name": "Michael Lagally"
-        },
-        {
-          "name": "Michael McCool"
-        },
-        {
-          "name": "Ryuichi Matsukura"
-        },
-        {
-          "name": "Sebastian Käbisch"
-        },
-        {
-          "name": "Tomoaki Mizushima"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
-      }
-    },
-    {
       "id": "https://www.w3.org/TR/wot-discovery/",
       "type": "TechArticle",
       "name": "Web of Things (WoT) Discovery",
@@ -537,6 +511,32 @@ dd{margin-left:0}
       ],
       "publisher": {
         "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-profile/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Profile",
+      "url": "https://www.w3.org/TR/wot-profile/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Sebastian Käbisch"
+        },
+        {
+          "name": "Tomoaki Mizushima"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
       }
     },
     {
@@ -4114,9 +4114,6 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
   <section id="sec-building-blocks"><div class="header-wrapper"><h2 id="x7-wot-building-blocks"><bdi class="secno">7. </bdi>WoT Building Blocks</h2><a class="self-link" href="#sec-building-blocks" aria-label="Permalink for Section 7."></a></div>
     
-    <p>
-      <em>This section is normative.</em>
-    </p>
     <p> The Web of Things (WoT) building blocks allow the
       implementation of systems that conform with the abstract WoT
       Architecture. The specifics of these building blocks are
@@ -4160,7 +4157,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       be considered an additional building block.
     </p>
 
-    <section id="sec-thing-description"><div class="header-wrapper"><h3 id="x7-1-wot-thing-description"><bdi class="secno">7.1 </bdi>WoT Thing Description</h3><a class="self-link" href="#sec-thing-description" aria-label="Permalink for Section 7.1"></a></div>
+    <section id="sec-thing-description" class="informative"><div class="header-wrapper"><h3 id="x7-1-wot-thing-description"><bdi class="secno">7.1 </bdi>WoT Thing Description</h3><a class="self-link" href="#sec-thing-description" aria-label="Permalink for Section 7.1"></a></div><p><em>This section is non-normative.</em></p>
       
       <p> The <a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-thing-description-12">WoT Thing Description</a> (TD) specification
         [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description 1.1">WOT-THING-DESCRIPTION</a></cite>] defines an <em>information model</em>
@@ -4223,7 +4220,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
 
 
-    <section id="sec-thing-model"><div class="header-wrapper"><h3 id="x7-2-thing-model"><bdi class="secno">7.2 </bdi>Thing Model</h3><a class="self-link" href="#sec-thing-model" aria-label="Permalink for Section 7.2"></a></div>
+    <section id="sec-thing-model" class="informative"><div class="header-wrapper"><h3 id="x7-2-thing-model"><bdi class="secno">7.2 </bdi>Thing Model</h3><a class="self-link" href="#sec-thing-model" aria-label="Permalink for Section 7.2"></a></div><p><em>This section is non-normative.</em></p>
       
 
       <p>The <a href="#dfn-wot-thing-model" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-thing-model-19">Thing Model</a> defines a template-based model for
@@ -4243,7 +4240,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     </section>
 
-    <section id="wot-profiles"><div class="header-wrapper"><h3 id="x7-3-profiles"><bdi class="secno">7.3 </bdi>Profiles</h3><a class="self-link" href="#wot-profiles" aria-label="Permalink for Section 7.3"></a></div>
+    <section id="wot-profiles" class="informative"><div class="header-wrapper"><h3 id="x7-3-profiles"><bdi class="secno">7.3 </bdi>Profiles</h3><a class="self-link" href="#wot-profiles" aria-label="Permalink for Section 7.3"></a></div><p><em>This section is non-normative.</em></p>
       
       <p>
       The <a href="#dfn-wot-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-profile-1">WoT Profile</a> Specification [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-profile" title="Web of Things (WoT) Profile">WOT-PROFILE</a></cite>] defines Profiles, 
@@ -4487,7 +4484,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     
 
-    <section id="sec-binding-templates" class="informative"><div class="header-wrapper"><h3 id="x7-5-wot-binding-templates"><bdi class="secno">7.5 </bdi>WoT Binding Templates</h3><a class="self-link" href="#sec-binding-templates" aria-label="Permalink for Section 7.5"></a></div><p><em>This section is non-normative.</em></p>
+    <section id="sec-binding-templates"><div class="header-wrapper"><h3 id="x7-5-wot-binding-templates"><bdi class="secno">7.5 </bdi>WoT Binding Templates</h3><a class="self-link" href="#sec-binding-templates" aria-label="Permalink for Section 7.5"></a></div>
       
 
 
@@ -4634,7 +4631,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     
 
-    <section id="sec-security-guidelines"><div class="header-wrapper"><h3 id="x7-7-wot-security-and-privacy-guidelines"><bdi class="secno">7.7 </bdi>WoT Security and Privacy Guidelines</h3><a class="self-link" href="#sec-security-guidelines" aria-label="Permalink for Section 7.7"></a></div>
+    <section id="sec-security-guidelines" class="informative"><div class="header-wrapper"><h3 id="x7-7-wot-security-and-privacy-guidelines"><bdi class="secno">7.7 </bdi>WoT Security and Privacy Guidelines</h3><a class="self-link" href="#sec-security-guidelines" aria-label="Permalink for Section 7.7"></a></div><p><em>This section is non-normative.</em></p>
       
       <p> Security is a cross-cutting concern and should be
         considered in all aspects of system design. In the WoT


### PR DESCRIPTION
Unfortunately, [PR 871](https://github.com/w3c/wot-architecture/pull/871) merged previously does not lead to a valid publication since, despite what we said earlier, sections 7.4 and 7.5 DO have assertions and must be normative.  Therefore, we cannot mark all of Section 7 as being informative.

This PR does the following:
- Marks section 7 as being normative again
- Marks any subsection of section 7 that does NOT have assertions as being informative.  So only sections 7.4 and 7.5 are normative
- Updates the CR candidate document in publication/ver11/3-cr to be consistent, and generates a static version, etc.

I believe this follows the intent of the original proposal as much as possible.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/872.html" title="Last updated on Nov 2, 2022, 2:32 PM UTC (415982c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/872/1c7ba10...mmccool:415982c.html" title="Last updated on Nov 2, 2022, 2:32 PM UTC (415982c)">Diff</a>