### PR TITLE
Remove Section 7 assertions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3125,7 +3125,7 @@
         "<a>exploration</a>" mechanisms that provide actual access to metadata.
         </p><p>
         The first and simplest <a>exploration</a> mechanism defines how to fetch a <a>TD</a>
-        directly from a simple web resource or from the device itself. This supports ad-hoc peer-to-peer discovery.
+        directly from the device itself. This supports ad-hoc peer-to-peer discovery.
         However, in many circumstances (including but not limited to management of 
         large collections of TDs), an alternative <a>exploration</a> mechanism,
         the <a>WoT Thing Description Directory</a> (<a>TDD</a>) service, 
@@ -3136,7 +3136,7 @@
         <a>TDDs</a> also provide change notification mechanisms 
         to support secure distribution of
         <a>TD</a> updates to authorized consumers.
-        To preserve security and privacy, any <a>WoT Discovery</a> "exploration"
+        Any <a>WoT Discovery</a> "exploration"
         implementation must only provide metadata and <a>TDs</a>
         after appropriate best-practice authentication and authorization.
         Suitable best-practice security mechanisms for authentication and authorization for 

--- a/index.html
+++ b/index.html
@@ -3102,17 +3102,15 @@
         </p>
         <ul>
         <li>
-        <span class="rfc2119-assertion" id="arch-discovery-no-metadata-in-introduction">
-        Any <a>introduction</a> mechanism used for <a>WoT Discovery</a> MUST NOT 
+        Any <a>introduction</a> mechanism used for <a>WoT Discovery</a> must not
         provide metadata but instead should simply result in 
         one or more opaque URLs at which metadata
         may be accessed, if and only if the user can authenticate and 
-        has the appropriate authorization (access rights).</span>
+        has the appropriate authorization (access rights).
         </li>
         <li>
-        <span class="rfc2119-assertion" id="arch-discovery-no-metadata-in-introduction-urls">
-        <a>Introduction</a> URLs MUST NOT themselves include any metadata,
-        e.g. a human-readable device type or name.</span>  
+        <a>Introduction</a> URLs must not themselves include any metadata,
+        e.g. a human-readable device type or name.  
         Randomly generated URLs are recommended.
         </li>
         </ul>
@@ -3126,7 +3124,7 @@
         "<a>exploration</a>" mechanisms that provide actual access to metadata.
         </p><p>
         The first and simplest <a>exploration</a> mechanism defines how to fetch a <a>TD</a>
-        directly from the device itself. This supports ad-hoc peer-to-peer discovery.
+        directly from a simple web resource or from the device itself. This supports ad-hoc peer-to-peer discovery.
         However, in many circumstances (including but not limited to management of 
         large collections of TDs), an alternative <a>exploration</a> mechanism,
         the <a>WoT Thing Description Directory</a> (<a>TDD</a>) service, 
@@ -3137,10 +3135,9 @@
         <a>TDDs</a> also provide change notification mechanisms 
         to support secure distribution of
         <a>TD</a> updates to authorized consumers.
-        <span class="rfc2119-assertion" id="arch-discovery-metadata-after-authorization">
-        Any <a>WoT Discovery</a> "exploration"
-        implementation MUST only provide metadata and <a>TDs</a>
-        after appropriate best-practice authentication and authorization.</span>
+        To preserve security and privacy, any <a>WoT Discovery</a> "exploration"
+        implementation must only provide metadata and <a>TDs</a>
+        after appropriate best-practice authentication and authorization.
         Suitable best-practice security mechanisms for authentication and authorization for 
         different circumstances are discussed in [[?WOT-SECURITY]].  
         Suitable mechanisms for managing access controls and keys are also discussed
@@ -3168,9 +3165,6 @@
         The <a>Discovery</a> mechanisms defined in [[!WOT-DISCOVERY]] are not mandatory, but
         they are designed to meet the above requirements and their use will enhance 
         interoperability and usability.
-        <span class="rfc2119-assertion" id="arch-discovery-should-use-standard">Whenever
-        possible, the <a>Discovery</a> mechanisms defined in [[!WOT-DISCOVERY]]
-        SHOULD be used to distribute <a>TDs</a>.</span>
         </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -298,9 +298,9 @@
       These sections are self contained, do not contain any assertion and other 
       specifications do not depend on these sections.</li>
       <li>Section 6 <a href="#sec-wot-architecture">Abstract WoT System Architecture</a>, 
-        section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
-        explain building blocks and architectural elements of the W3C WoT. 
-        These sections are normative and contain many assertions that are relevant for WoT implementations. </li>
+        This section is normative and contains assertions that are relevant for WoT implementations.</li>
+      <li>Section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
+        explains building blocks and architectural elements of the W3C WoT.</li> 
       <li>Section 8 <a href="#sec-servient-implementation">Abstract Servient Architecture</a> describes
         the architecture of a <a>Servient</a>. It informatively describes how to implement a <a>WoT Runtime</a> on a device.</li>
       <li>Section 9 <a href="#sec-deployment-scenario">Example WoT Deployments</a> 
@@ -2935,7 +2935,7 @@
     <section id="wot-profiles">
       <h3>Profiles</h3>
       <p>
-      The <a>WoT Profile</a> Specification [[!WOT-PROFILE]] defines Profiles, 
+      The <a>WoT Profile</a> Specification [[?WOT-PROFILE]] defines Profiles, 
       that enable <em>out of the box interoperability</em> among things 
       and devices. Out of the box interoperability implies, 
       that devices can be integrated into various application 

--- a/index.html
+++ b/index.html
@@ -298,9 +298,10 @@
       These sections are self contained, do not contain any assertion and other 
       specifications do not depend on these sections.</li>
       <li>Section 6 <a href="#sec-wot-architecture">Abstract WoT System Architecture</a>, 
+        explains architectural elements of the W3C WoT. 
         This section is normative and contains assertions that are relevant for WoT implementations.</li>
       <li>Section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
-        explains building blocks and architectural elements of the W3C WoT.</li> 
+        explains building blocks of the W3C WoT.</li> 
       <li>Section 8 <a href="#sec-servient-implementation">Abstract Servient Architecture</a> describes
         the architecture of a <a>Servient</a>. It informatively describes how to implement a <a>WoT Runtime</a> on a device.</li>
       <li>Section 9 <a href="#sec-deployment-scenario">Example WoT Deployments</a> 

--- a/index.html
+++ b/index.html
@@ -3237,11 +3237,9 @@
             <li>
                 <b>Subprotocol</b>
                 <p>
-                  <span class="rfc2119-assertion" id="arch-binding-templates-known-subprotocol">
-                    <a>Transport protocols</a> MAY have to use information provided by an extension mechanisms to interact successfully.</span>
-                  <span class="rfc2119-assertion" id="arch-binding-templates-subprotocol-explicit-declaration">
-                  Such <a>subprotocols</a> cannot be identified from the URI scheme alone and MUST be declared explicitly
-                  using the <code>subprotocol</code> field inside forms.</span>
+                  <a>Transport protocols</a> may have to use information provided by an extension mechanisms to interact successfully.
+                  Such <a>subprotocols</a> cannot be identified from the URI scheme alone and must be declared explicitly
+                  using the <code>subprotocol</code> field inside forms.
                   Examples for HTTP are long polling [[?RFC6202]] (<code>longpoll</code>) or 
                   Server-Sent Events [[?HTML]] (<code>sse</code>).
                 </p>
@@ -3253,12 +3251,10 @@
           <p>
             Representation formats (a.k.a. serializations) used for exchanging data can differ between protocols, 
             <a>IoT Platforms</a> and standards.
-            <span class="rfc2119-assertion" id="arch-binding-templates-media-type-parameters">
-            The media type [[!RFC2046]] identifies these formats, while media type parameters MAY specify them further.</span>
-            <span class="rfc2119-assertion" id="arch-binding-templates-media-type-optional-parameters">
-            Forms MAY contain the media type and optional parameters in additional form fields such as a content type 
+            The media type [[?RFC2046]] identifies these formats, while media type parameters may specify them further.
+            Forms may contain the media type and optional parameters in additional form fields such as a content type 
             field known from HTTP, which combines media type and its potential parameters
-            (e.g., <code>text/plain; charset=utf-8</code>).</span>
+            (e.g., <code>text/plain; charset=utf-8</code>).
           </p>
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -3162,7 +3162,7 @@
         </p>
        </section>
         <p>
-        The <a>Discovery</a> mechanisms defined in [[!WOT-DISCOVERY]] are not mandatory, but
+        The <a>Discovery</a> mechanisms defined in [[?WOT-DISCOVERY]] are not mandatory, but
         they are designed to meet the above requirements and their use will enhance 
         interoperability and usability.
         </p>

--- a/publication/ver11/3-cr/Overview.html
+++ b/publication/ver11/3-cr/Overview.html
@@ -210,7 +210,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
-  "datePublished": "2022-11-02",
+  "datePublished": "2022-11-03",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -421,55 +421,6 @@ dd{margin-left:0}
       }
     },
     {
-      "id": "https://www.w3.org/TR/wot-profile/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Profile",
-      "url": "https://www.w3.org/TR/wot-profile/",
-      "creator": [
-        {
-          "name": "Michael Lagally"
-        },
-        {
-          "name": "Michael McCool"
-        },
-        {
-          "name": "Ryuichi Matsukura"
-        },
-        {
-          "name": "Sebastian Käbisch"
-        },
-        {
-          "name": "Tomoaki Mizushima"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
-      }
-    },
-    {
-      "id": "https://www.w3.org/TR/wot-discovery/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Discovery",
-      "url": "https://www.w3.org/TR/wot-discovery/",
-      "creator": [
-        {
-          "name": "Andrea Cimmino"
-        },
-        {
-          "name": "Michael McCool"
-        },
-        {
-          "name": "Farshid Tavakolizadeh"
-        },
-        {
-          "name": "Kunihiko Toumura"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
-      }
-    },
-    {
       "id": "https://www.rfc-editor.org/rfc/rfc8446",
       "type": "TechArticle",
       "name": "The Transport Layer Security (TLS) Protocol Version 1.3",
@@ -535,6 +486,55 @@ dd{margin-left:0}
       ],
       "publisher": {
         "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-discovery/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Discovery",
+      "url": "https://www.w3.org/TR/wot-discovery/",
+      "creator": [
+        {
+          "name": "Andrea Cimmino"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Farshid Tavakolizadeh"
+        },
+        {
+          "name": "Kunihiko Toumura"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-profile/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Profile",
+      "url": "https://www.w3.org/TR/wot-profile/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Sebastian Käbisch"
+        },
+        {
+          "name": "Tomoaki Mizushima"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
       }
     },
     {
@@ -1449,8 +1449,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2022-11-02T00:00:00.000Z",
-  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 02 November 2022"
+  "publishISODate": "2022-11-03T00:00:00.000Z",
+  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 03 November 2022"
 }
 </script>
 <link rel="stylesheet" href=
@@ -1467,13 +1467,13 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 <p id="w3c-state"><a href=
 "https://www.w3.org/standards/types#CR">W3C Candidate
 Recommendation Snapshot</a> <time class="dt-published" datetime=
-"2022-11-02">02 November 2022</time></p>
+"2022-11-03">03 November 2022</time></p>
 <details open="">
 <summary>More details about this document</summary>
 <dl>
 <dt>This version:</dt>
 <dd><a class="u-url" href=
-"https://www.w3.org/TR/2022/CR-wot-architecture11-20221102/">https://www.w3.org/TR/2022/CR-wot-architecture11-20221102/</a></dd>
+"https://www.w3.org/TR/2022/CR-wot-architecture11-20221103/">https://www.w3.org/TR/2022/CR-wot-architecture11-20221103/</a></dd>
 <dt>Latest published version:</dt>
 <dd><a href=
 "https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a></dd>
@@ -1584,11 +1584,13 @@ explain ways to use WoT. These sections are self contained, do not
 contain any assertion and other specifications do not depend on
 these sections.</li>
 <li>Section 6 <a href="#sec-wot-architecture">Abstract WoT System
-Architecture</a>, section 7 <a href="#sec-building-blocks">WoT
-Building Blocks</a>, explain building blocks and architectural
-elements of the <abbr title="World Wide Web Consortium">W3C</abbr>
-WoT. These sections are normative and contain many assertions that
-are relevant for WoT implementations.</li>
+Architecture</a>, explains architectural elements of the
+<abbr title="World Wide Web Consortium">W3C</abbr> WoT. This
+section is normative and contains assertions that are relevant for
+WoT implementations.</li>
+<li>Section 7 <a href="#sec-building-blocks">WoT Building
+Blocks</a>, explains building blocks of the <abbr title=
+"World Wide Web Consortium">W3C</abbr> WoT.</li>
 <li>Section 8 <a href="#sec-servient-implementation">Abstract
 Servient Architecture</a> describes the architecture of a <a href=
 "#dfn-servient" class="internalDFN" data-link-type="dfn" id=
@@ -2907,7 +2909,7 @@ WoT Thing Description.</dd>
 <dt><dfn id="dfn-wot-profile" tabindex="0" aria-haspopup="dialog"
 data-dfn-type="dfn">WoT Profile</dfn></dt>
 <dd>Synonym for <a href="#dfn-profile" class="internalDFN"
-data-link-type="dfn" id="ref-for-dfn-profile-1">Profile</a>.</dd>
+data-link-type="dfn" id="ref-for-dfn-profile-1">Profile</a></dd>
 <dt><dfn id="dfn-wot-runtime" tabindex="0" aria-haspopup="dialog"
 data-dfn-type="dfn">WoT Runtime</dfn></dt>
 <dd>A runtime system that maintains an execution environment for
@@ -5507,13 +5509,13 @@ protocols.</span></p>
 </section>
 </section>
 </section>
-<section id="sec-building-blocks">
+<section id="sec-building-blocks" class="informative">
 <div class="header-wrapper">
 <h2 id="x7-wot-building-blocks"><bdi class="secno">7.</bdi> WoT
 Building Blocks</h2>
 <a class="self-link" href="#sec-building-blocks" aria-label=
 "Permalink for Section 7."></a></div>
-<p><em>This section is normative.</em></p>
+<p><em>This section is non-normative.</em></p>
 <p>The Web of Things (WoT) building blocks allow the implementation
 of systems that conform with the abstract WoT Architecture. The
 specifics of these building blocks are defined in separate
@@ -5920,24 +5922,20 @@ this allows a variety of existing discovery mechanisms with
 relatively weak security to be used, as long as they satisfy the
 following requirements:</p>
 <ul>
-<li><span class="rfc2119-assertion" id=
-"arch-discovery-no-metadata-in-introduction">Any <a href=
-"#dfn-wot-introduction" class="internalDFN" data-link-type="dfn"
-id="ref-for-dfn-wot-introduction-3">introduction</a> mechanism used
+<li>Any <a href="#dfn-wot-introduction" class="internalDFN"
+data-link-type="dfn" id=
+"ref-for-dfn-wot-introduction-3">introduction</a> mechanism used
 for <a href="#dfn-wot-discovery" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-wot-discovery-11">WoT
-Discovery</a> <em class="rfc2119">MUST NOT</em> provide metadata
-but instead should simply result in one or more opaque URLs at
-which metadata may be accessed, if and only if the user can
-authenticate and has the appropriate authorization (access
-rights).</span></li>
-<li><span class="rfc2119-assertion" id=
-"arch-discovery-no-metadata-in-introduction-urls"><a href=
-"#dfn-wot-introduction" class="internalDFN" data-link-type="dfn"
-id="ref-for-dfn-wot-introduction-4">Introduction</a> URLs
-<em class="rfc2119">MUST NOT</em> themselves include any metadata,
-e.g. a human-readable device type or name.</span> Randomly
-generated URLs are recommended.</li>
+Discovery</a> must not provide metadata but instead should simply
+result in one or more opaque URLs at which metadata may be
+accessed, if and only if the user can authenticate and has the
+appropriate authorization (access rights).</li>
+<li><a href="#dfn-wot-introduction" class="internalDFN"
+data-link-type="dfn" id=
+"ref-for-dfn-wot-introduction-4">Introduction</a> URLs must not
+themselves include any metadata, e.g. a human-readable device type
+or name. Randomly generated URLs are recommended.</li>
 </ul>
 </section>
 <section id="sec-discovery-exploration">
@@ -5978,17 +5976,15 @@ protected) query mechanisms to explore and retrieve WoT metadata.
 "ref-for-dfn-tdd-3">TDDs</a> also provide change notification
 mechanisms to support secure distribution of <a href="#dfn-td"
 class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-19">TD</a> updates to authorized consumers.
-<span class="rfc2119-assertion" id=
-"arch-discovery-metadata-after-authorization">Any <a href=
-"#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-wot-discovery-13">WoT Discovery</a> "exploration"
-implementation <em class="rfc2119">MUST</em> only provide metadata
-and <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id=
+"ref-for-dfn-td-19">TD</a> updates to authorized consumers. Any
+<a href="#dfn-wot-discovery" class="internalDFN" data-link-type=
+"dfn" id="ref-for-dfn-wot-discovery-13">WoT Discovery</a>
+"exploration" implementation must only provide metadata and
+<a href="#dfn-td" class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-td-20">TDs</a> after appropriate best-practice
-authentication and authorization.</span> Suitable best-practice
-security mechanisms for authentication and authorization for
-different circumstances are discussed in [<cite><a class="bibref"
+authentication and authorization. Suitable best-practice security
+mechanisms for authentication and authorization for different
+circumstances are discussed in [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-security" title=
 "Web of Things (WoT) Security and Privacy Guidelines">WOT-SECURITY</a></cite>].
 Suitable mechanisms for managing access controls and keys are also
@@ -6026,25 +6022,14 @@ data-link-type="dfn" id=
 "#bib-wot-discovery" title=
 "Web of Things (WoT) Discovery">WOT-DISCOVERY</a></cite>] are not
 mandatory, but they are designed to meet the above requirements and
-their use will enhance interoperability and usability. <span class=
-"rfc2119-assertion" id=
-"arch-discovery-should-use-standard">Whenever possible, the
-<a href="#dfn-wot-discovery" class="internalDFN" data-link-type=
-"dfn" id="ref-for-dfn-wot-discovery-15">Discovery</a> mechanisms
-defined in [<cite><a class="bibref" data-link-type="biblio" href=
-"#bib-wot-discovery" title=
-"Web of Things (WoT) Discovery">WOT-DISCOVERY</a></cite>]
-<em class="rfc2119">SHOULD</em> be used to distribute <a href=
-"#dfn-td" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-23">TDs</a>.</span></p>
+their use will enhance interoperability and usability.</p>
 </section>
-<section id="sec-binding-templates" class="informative">
+<section id="sec-binding-templates">
 <div class="header-wrapper">
 <h3 id="x7-5-wot-binding-templates"><bdi class="secno">7.5</bdi>
 WoT Binding Templates</h3>
 <a class="self-link" href="#sec-binding-templates" aria-label=
 "Permalink for Section 7.5"></a></div>
-<p><em>This section is non-normative.</em></p>
 <p>The IoT uses a variety of protocols for accessing devices, since
 no single protocol is appropriate in all contexts. Thus, a central
 challenge for the Web of Things is to enable interactions with the
@@ -6124,18 +6109,18 @@ class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-wot-binding-templates-6">Binding Templates</a> are
 used. Based on the protocol, media type or platform binding, a
 <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-24">TD</a> is created. The <a href="#dfn-consumer"
+"ref-for-dfn-td-23">TD</a> is created. The <a href="#dfn-consumer"
 class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-consumer-54">Consumer</a> that is processing a
 <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-25">TD</a> implements the required <a href=
+"ref-for-dfn-td-24">TD</a> implements the required <a href=
 "#dfn-wot-binding-templates" class="internalDFN" data-link-type=
 "dfn" id="ref-for-dfn-wot-binding-templates-7">Binding Template</a>
 that is present in the TD by including a corresponding protocol
 stack, media type encoder/decoder or platform stack and by
 configuring the stack (or its messages) according to the
 information given in the <a href="#dfn-td" class="internalDFN"
-data-link-type="dfn" id="ref-for-dfn-td-26">TD</a> such as
+data-link-type="dfn" id="ref-for-dfn-td-25">TD</a> such as
 serialization format of the messages and header options.</p>
 <p>The <a href="#dfn-wot-binding-templates" class="internalDFN"
 data-link-type="dfn" id=
@@ -6161,21 +6146,17 @@ HTTP, CoAPS, or WebSocket through <code>http</code>,
 <code>coaps</code>, or <code>ws</code>, respectively.</p>
 <ul>
 <li><b>Subprotocol</b>
-<p><span class="rfc2119-assertion" id=
-"arch-binding-templates-known-subprotocol"><a href=
-"#dfn-transport-protocol" class="internalDFN" data-link-type="dfn"
-id="ref-for-dfn-transport-protocol-6">Transport protocols</a>
-<em class="rfc2119">MAY</em> have to use information provided by an
-extension mechanisms to interact successfully.</span> <span class=
-"rfc2119-assertion" id=
-"arch-binding-templates-subprotocol-explicit-declaration">Such
-<a href="#dfn-subprotocol" class="internalDFN" data-link-type="dfn"
-id="ref-for-dfn-subprotocol-2">subprotocols</a> cannot be
-identified from the URI scheme alone and <em class=
-"rfc2119">MUST</em> be declared explicitly using the
-<code>subprotocol</code> field inside forms.</span> Examples for
-HTTP are long polling [<cite><a class="bibref" data-link-type=
-"biblio" href="#bib-rfc6202" title=
+<p><a href="#dfn-transport-protocol" class="internalDFN"
+data-link-type="dfn" id=
+"ref-for-dfn-transport-protocol-6">Transport protocols</a> may have
+to use information provided by an extension mechanisms to interact
+successfully. Such <a href="#dfn-subprotocol" class="internalDFN"
+data-link-type="dfn" id=
+"ref-for-dfn-subprotocol-2">subprotocols</a> cannot be identified
+from the URI scheme alone and must be declared explicitly using the
+<code>subprotocol</code> field inside forms. Examples for HTTP are
+long polling [<cite><a class="bibref" data-link-type="biblio" href=
+"#bib-rfc6202" title=
 "Known Issues and Best Practices for the Use of Long Polling and Streaming in Bidirectional HTTP">RFC6202</a></cite>]
 (<code>longpoll</code>) or Server-Sent Events [<cite><a class=
 "bibref" data-link-type="biblio" href="#bib-html" title=
@@ -6187,21 +6168,15 @@ HTTP are long polling [<cite><a class="bibref" data-link-type=
 <p>Representation formats (a.k.a. serializations) used for
 exchanging data can differ between protocols, <a href=
 "#dfn-iot-platform" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-iot-platform-5">IoT Platforms</a> and standards.
-<span class="rfc2119-assertion" id=
-"arch-binding-templates-media-type-parameters">The media type
-[<cite><a class="bibref" data-link-type="biblio" href=
+"ref-for-dfn-iot-platform-5">IoT Platforms</a> and standards. The
+media type [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc2046" title=
 "Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]
-identifies these formats, while media type parameters <em class=
-"rfc2119">MAY</em> specify them further.</span> <span class=
-"rfc2119-assertion" id=
-"arch-binding-templates-media-type-optional-parameters">Forms
-<em class="rfc2119">MAY</em> contain the media type and optional
+identifies these formats, while media type parameters may specify
+them further. Forms may contain the media type and optional
 parameters in additional form fields such as a content type field
 known from HTTP, which combines media type and its potential
-parameters (e.g., <code>text/plain;
-charset=utf-8</code>).</span></p>
+parameters (e.g., <code>text/plain; charset=utf-8</code>).</p>
 </li>
 <li><b>Platforms and Standards</b>
 <p><a href="#dfn-iot-platform" class="internalDFN" data-link-type=
@@ -6213,19 +6188,18 @@ media types that need to be accurately incorporated into each
 message between the Thing and its Consumer. Both the protocol
 modification and payload representation specific to different
 platforms can be represented in <a href="#dfn-td" class=
-"internalDFN" data-link-type="dfn" id="ref-for-dfn-td-27">TDs</a>
+"internalDFN" data-link-type="dfn" id="ref-for-dfn-td-26">TDs</a>
 using the best practices documented in binding templates for
 platforms and standards.</p>
 </li>
 </ul>
 </section>
-<section id="sec-scripting-api" class="informative">
+<section id="sec-scripting-api">
 <div class="header-wrapper">
 <h3 id="x7-6-wot-scripting-api"><bdi class="secno">7.6</bdi> WoT
 Scripting API</h3>
 <a class="self-link" href="#sec-scripting-api" aria-label=
 "Permalink for Section 7.6"></a></div>
-<p><em>This section is non-normative.</em></p>
 <p>The <a href="#dfn-wot-scripting-api" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-wot-scripting-api-3">WoT
 Scripting API</a> is an optional "convenience" building block of
@@ -6306,7 +6280,7 @@ supported by certain explicit features, such as support for
 data-link-type="dfn" id=
 "ref-for-dfn-public-security-metadata-3">Public Security
 Metadata</a> in <a href="#dfn-td" class="internalDFN"
-data-link-type="dfn" id="ref-for-dfn-td-28">TDs</a> and by
+data-link-type="dfn" id="ref-for-dfn-td-27">TDs</a> and by
 separation of concerns in the design of the <a href=
 "#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn"
 id="ref-for-dfn-wot-scripting-api-8">WoT Scripting API</a>. The
@@ -6622,7 +6596,7 @@ Runtime</a> instantiates software representations of <a href=
 "#dfn-thing" class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-thing-133">Things</a> based on their <a href="#dfn-td"
 class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-29">TDs</a>. These software representations provide
+"ref-for-dfn-td-28">TDs</a>. These software representations provide
 the interface towards the behavior implementation.</p>
 <p>The <a href="#dfn-exposed-thing" class="internalDFN"
 data-link-type="dfn" id="ref-for-dfn-exposed-thing-12">Exposed
@@ -6655,7 +6629,7 @@ reading their metadata and activating their <a href=
 "dfn" id="ref-for-dfn-interaction-affordance-31">Interaction
 Affordances</a> as described in the corresponding <a href="#dfn-td"
 class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-30">TD</a>. <a href="#dfn-consumed-thing" class=
+"ref-for-dfn-td-29">TD</a>. <a href="#dfn-consumed-thing" class=
 "internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-consumed-thing-13">Consumed Things</a> can also
 represent system features such as local hardware or devices behind
@@ -6666,7 +6640,7 @@ necessary adaptation between system API and <a href=
 "#dfn-consumed-thing" class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-consumed-thing-14">Consumed Thing</a>. Furthermore, it
 must provide corresponding <a href="#dfn-td" class="internalDFN"
-data-link-type="dfn" id="ref-for-dfn-td-31">TDs</a> and make them
+data-link-type="dfn" id="ref-for-dfn-td-30">TDs</a> and make them
 available to the behavior implementation, for instance, by
 extending whatever discovery mechanism is provided by the <a href=
 "#dfn-wot-runtime" class="internalDFN" data-link-type="dfn" id=
@@ -6843,7 +6817,7 @@ when it is possible to provide a well-formed <a href=
 "dfn" id="ref-for-dfn-wot-thing-description-23">WoT Thing
 Description</a> for them. In this case, the <a href="#dfn-td"
 class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-td-32">TD</a> describes a <a href="#dfn-wot-interface"
+"ref-for-dfn-td-31">TD</a> describes a <a href="#dfn-wot-interface"
 class="internalDFN" data-link-type="dfn" id=
 "ref-for-dfn-wot-interface-11">WoT Interface</a> of a <a href=
 "#dfn-thing" class="internalDFN" data-link-type="dfn" id=
@@ -7027,7 +7001,7 @@ data-link-type="dfn" id=
 Directory</a>, a discovery protocol, through static assignment,
 etc. As discussed elsewhere, use of the <a href=
 "#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-wot-discovery-16">Discovery</a> mechanisms defined in
+"ref-for-dfn-wot-discovery-15">Discovery</a> mechanisms defined in
 [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-discovery" title=
 "Web of Things (WoT) Discovery">WOT-DISCOVERY</a></cite>] is
@@ -7765,7 +7739,7 @@ Data</a>.</span> <span class="rfc2119-assertion" id=
 "#dfn-private-security-data" class="internalDFN" data-link-type=
 "dfn" id="ref-for-dfn-private-security-data-8">Private Security
 Data</a> is included in <a href="#dfn-td" class="internalDFN"
-data-link-type="dfn" id="ref-for-dfn-td-33">TDs</a>.</span></dd>
+data-link-type="dfn" id="ref-for-dfn-td-32">TDs</a>.</span></dd>
 </dl>
 </section>
 <section id="sec-security-consideration-td-cm">
@@ -8281,7 +8255,7 @@ contain it.</span> <span class="rfc2119-assertion" id=
 for TDs <em class="rfc2119">SHOULD</em> ensure they are only
 provided to authorized Consumers.</span> Note that the <a href=
 "#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id=
-"ref-for-dfn-wot-discovery-17">WoT Discovery</a> mechanism is
+"ref-for-dfn-wot-discovery-16">WoT Discovery</a> mechanism is
 designed to address these specific issues, as long as it is used
 with authentication and access controls on exploration services. As
 a general matter of policy, unnecessary information should not be
@@ -9260,9 +9234,8 @@ Permalink</a></div>
 "#ref-for-dfn-wot-discovery-8" title="Reference 3">(3)</a> <a href=
 "#ref-for-dfn-wot-discovery-9" title="Reference 4">(4)</a> <a href=
 "#ref-for-dfn-wot-discovery-10" title="Reference 5">(5)</a>
-<a href="#ref-for-dfn-wot-discovery-14" title="Reference 6">(6)</a>
-<a href="#ref-for-dfn-wot-discovery-15" title=
-"Reference 7">(7)</a></li>
+<a href="#ref-for-dfn-wot-discovery-14" title=
+"Reference 6">(6)</a></li>
 <li><a href="#ref-for-dfn-wot-discovery-11" title=
 "§ 7.4.1 Introduction Mechanisms">§ 7.4.1 Introduction
 Mechanisms</a></li>
@@ -9270,10 +9243,10 @@ Mechanisms</a></li>
 "§ 7.4.2 Exploration Mechanisms">§ 7.4.2 Exploration Mechanisms</a>
 <a href="#ref-for-dfn-wot-discovery-13" title=
 "Reference 2">(2)</a></li>
-<li><a href="#ref-for-dfn-wot-discovery-16" title=
+<li><a href="#ref-for-dfn-wot-discovery-15" title=
 "§ 9.1 Thing and Consumer Roles">§ 9.1 Thing and Consumer
 Roles</a></li>
-<li><a href="#ref-for-dfn-wot-discovery-17" title=
+<li><a href="#ref-for-dfn-wot-discovery-16" title=
 "§ 11.1.1 Thing Description Personally Identifiable Information Risk">
 § 11.1.1 Thing Description Personally Identifiable Information
 Risk</a></li>
@@ -10209,31 +10182,30 @@ Communication</a></li>
 "#ref-for-dfn-td-15" title="Reference 8">(8)</a> <a href=
 "#ref-for-dfn-td-16" title="Reference 9">(9)</a></li>
 <li><a href="#ref-for-dfn-td-17" title="§ 7.4 WoT Discovery">§ 7.4
-WoT Discovery</a> <a href="#ref-for-dfn-td-23" title=
-"Reference 2">(2)</a></li>
+WoT Discovery</a></li>
 <li><a href="#ref-for-dfn-td-18" title=
 "§ 7.4.2 Exploration Mechanisms">§ 7.4.2 Exploration Mechanisms</a>
 <a href="#ref-for-dfn-td-19" title="Reference 2">(2)</a> <a href=
 "#ref-for-dfn-td-20" title="Reference 3">(3)</a> <a href=
 "#ref-for-dfn-td-21" title="Reference 4">(4)</a> <a href=
 "#ref-for-dfn-td-22" title="Reference 5">(5)</a></li>
-<li><a href="#ref-for-dfn-td-24" title=
+<li><a href="#ref-for-dfn-td-23" title=
 "§ 7.5 WoT Binding Templates">§ 7.5 WoT Binding Templates</a>
-<a href="#ref-for-dfn-td-25" title="Reference 2">(2)</a> <a href=
-"#ref-for-dfn-td-26" title="Reference 3">(3)</a> <a href=
-"#ref-for-dfn-td-27" title="Reference 4">(4)</a></li>
-<li><a href="#ref-for-dfn-td-28" title=
+<a href="#ref-for-dfn-td-24" title="Reference 2">(2)</a> <a href=
+"#ref-for-dfn-td-25" title="Reference 3">(3)</a> <a href=
+"#ref-for-dfn-td-26" title="Reference 4">(4)</a></li>
+<li><a href="#ref-for-dfn-td-27" title=
 "§ 7.7 WoT Security and Privacy Guidelines">§ 7.7 WoT Security and
 Privacy Guidelines</a></li>
-<li><a href="#ref-for-dfn-td-29" title=
+<li><a href="#ref-for-dfn-td-28" title=
 "§ 8.4 Exposed Thing and Consumed Thing Abstractions">§ 8.4 Exposed
 Thing and Consumed Thing Abstractions</a> <a href=
-"#ref-for-dfn-td-30" title="Reference 2">(2)</a> <a href=
-"#ref-for-dfn-td-31" title="Reference 3">(3)</a></li>
-<li><a href="#ref-for-dfn-td-32" title=
+"#ref-for-dfn-td-29" title="Reference 2">(2)</a> <a href=
+"#ref-for-dfn-td-30" title="Reference 3">(3)</a></li>
+<li><a href="#ref-for-dfn-td-31" title=
 "§ 8.8 Alternative Servient and WoT Implementations">§ 8.8
 Alternative Servient and WoT Implementations</a></li>
-<li><a href="#ref-for-dfn-td-33" title=
+<li><a href="#ref-for-dfn-td-32" title=
 "§ 10.1.1 Thing Description Private Security Data Risk">§ 10.1.1
 Thing Description Private Security Data Risk</a></li>
 </ul>

--- a/publication/ver11/3-cr/index.html
+++ b/publication/ver11/3-cr/index.html
@@ -354,9 +354,10 @@
       These sections are self contained, do not contain any assertion and other 
       specifications do not depend on these sections.</li>
       <li>Section 6 <a href="#sec-wot-architecture">Abstract WoT System Architecture</a>, 
-        section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
-        explain building blocks and architectural elements of the W3C WoT. 
-        These sections are normative and contain many assertions that are relevant for WoT implementations. </li>
+        explains architectural elements of the W3C WoT. 
+        This section is normative and contains assertions that are relevant for WoT implementations.</li>
+      <li>Section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
+        explains building blocks of the W3C WoT.</li> 
       <li>Section 8 <a href="#sec-servient-implementation">Abstract Servient Architecture</a> describes
         the architecture of a <a>Servient</a>. It informatively describes how to implement a <a>WoT Runtime</a> on a device.</li>
       <li>Section 9 <a href="#sec-deployment-scenario">Example WoT Deployments</a> 
@@ -1011,7 +1012,7 @@
       <dt>
         <dfn>WoT Profile</dfn>
       </dt>
-      <dd>Synonym for <a>Profile</a>.</dd>	    
+      <dd>Synonym for <a>Profile</a></dd>	    
       <dt>
         <dfn>WoT Runtime</dfn>
       </dt>
@@ -2907,11 +2908,8 @@
     </section>
   </section>
 
-  <section id="sec-building-blocks">
+  <section id="sec-building-blocks" class="informative">
     <h1>WoT Building Blocks</h1>
-    <p>
-      <em>This section is normative.</em>
-    </p>
     <p> The Web of Things (WoT) building blocks allow the
       implementation of systems that conform with the abstract WoT
       Architecture. The specifics of these building blocks are
@@ -3042,7 +3040,7 @@
     <section id="wot-profiles">
       <h3>Profiles</h3>
       <p>
-      The <a>WoT Profile</a> Specification [[!WOT-PROFILE]] defines Profiles, 
+      The <a>WoT Profile</a> Specification [[?WOT-PROFILE]] defines Profiles, 
       that enable <em>out of the box interoperability</em> among things 
       and devices. Out of the box interoperability implies, 
       that devices can be integrated into various application 
@@ -3209,17 +3207,15 @@
         </p>
         <ul>
         <li>
-        <span class="rfc2119-assertion" id="arch-discovery-no-metadata-in-introduction">
-        Any <a>introduction</a> mechanism used for <a>WoT Discovery</a> MUST NOT 
+        Any <a>introduction</a> mechanism used for <a>WoT Discovery</a> must not
         provide metadata but instead should simply result in 
         one or more opaque URLs at which metadata
         may be accessed, if and only if the user can authenticate and 
-        has the appropriate authorization (access rights).</span>
+        has the appropriate authorization (access rights).
         </li>
         <li>
-        <span class="rfc2119-assertion" id="arch-discovery-no-metadata-in-introduction-urls">
-        <a>Introduction</a> URLs MUST NOT themselves include any metadata,
-        e.g. a human-readable device type or name.</span>  
+        <a>Introduction</a> URLs must not themselves include any metadata,
+        e.g. a human-readable device type or name.  
         Randomly generated URLs are recommended.
         </li>
         </ul>
@@ -3244,10 +3240,9 @@
         <a>TDDs</a> also provide change notification mechanisms 
         to support secure distribution of
         <a>TD</a> updates to authorized consumers.
-        <span class="rfc2119-assertion" id="arch-discovery-metadata-after-authorization">
         Any <a>WoT Discovery</a> "exploration"
-        implementation MUST only provide metadata and <a>TDs</a>
-        after appropriate best-practice authentication and authorization.</span>
+        implementation must only provide metadata and <a>TDs</a>
+        after appropriate best-practice authentication and authorization.
         Suitable best-practice security mechanisms for authentication and authorization for 
         different circumstances are discussed in [[?WOT-SECURITY]].  
         Suitable mechanisms for managing access controls and keys are also discussed
@@ -3272,18 +3267,15 @@
         </p>
        </section>
         <p>
-        The <a>Discovery</a> mechanisms defined in [[!WOT-DISCOVERY]] are not mandatory, but
+        The <a>Discovery</a> mechanisms defined in [[?WOT-DISCOVERY]] are not mandatory, but
         they are designed to meet the above requirements and their use will enhance 
         interoperability and usability.
-        <span class="rfc2119-assertion" id="arch-discovery-should-use-standard">Whenever
-        possible, the <a>Discovery</a> mechanisms defined in [[!WOT-DISCOVERY]]
-        SHOULD be used to distribute <a>TDs</a>.</span>
         </p>
     </section>
 
     <!-- Binding Templates -->
 
-    <section id="sec-binding-templates" class="informative">
+    <section id="sec-binding-templates" >
       <h3>WoT Binding Templates</h3>
 
 
@@ -3350,11 +3342,9 @@
             <li>
                 <b>Subprotocol</b>
                 <p>
-                  <span class="rfc2119-assertion" id="arch-binding-templates-known-subprotocol">
-                    <a>Transport protocols</a> MAY have to use information provided by an extension mechanisms to interact successfully.</span>
-                  <span class="rfc2119-assertion" id="arch-binding-templates-subprotocol-explicit-declaration">
-                  Such <a>subprotocols</a> cannot be identified from the URI scheme alone and MUST be declared explicitly
-                  using the <code>subprotocol</code> field inside forms.</span>
+                  <a>Transport protocols</a> may have to use information provided by an extension mechanisms to interact successfully.
+                  Such <a>subprotocols</a> cannot be identified from the URI scheme alone and must be declared explicitly
+                  using the <code>subprotocol</code> field inside forms.
                   Examples for HTTP are long polling [[?RFC6202]] (<code>longpoll</code>) or 
                   Server-Sent Events [[?HTML]] (<code>sse</code>).
                 </p>
@@ -3366,12 +3356,10 @@
           <p>
             Representation formats (a.k.a. serializations) used for exchanging data can differ between protocols, 
             <a>IoT Platforms</a> and standards.
-            <span class="rfc2119-assertion" id="arch-binding-templates-media-type-parameters">
-            The media type [[!RFC2046]] identifies these formats, while media type parameters MAY specify them further.</span>
-            <span class="rfc2119-assertion" id="arch-binding-templates-media-type-optional-parameters">
-            Forms MAY contain the media type and optional parameters in additional form fields such as a content type 
+            The media type [[?RFC2046]] identifies these formats, while media type parameters may specify them further.
+            Forms may contain the media type and optional parameters in additional form fields such as a content type 
             field known from HTTP, which combines media type and its potential parameters
-            (e.g., <code>text/plain; charset=utf-8</code>).</span>
+            (e.g., <code>text/plain; charset=utf-8</code>).
           </p>
         </li>
         <li>
@@ -3390,7 +3378,7 @@
 
     <!-- Scripting -->
 
-    <section id="sec-scripting-api" class="informative">
+    <section id="sec-scripting-api">
       <h3>WoT Scripting API</h3>
       <p> The <a>WoT Scripting API</a> is an optional "convenience"
         building block of W3C WoT that eases IoT application

--- a/publication/ver11/3-cr/static.html
+++ b/publication/ver11/3-cr/static.html
@@ -212,7 +212,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
-  "datePublished": "2022-11-02",
+  "datePublished": "2022-11-03",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -423,55 +423,6 @@ dd{margin-left:0}
       }
     },
     {
-      "id": "https://www.w3.org/TR/wot-profile/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Profile",
-      "url": "https://www.w3.org/TR/wot-profile/",
-      "creator": [
-        {
-          "name": "Michael Lagally"
-        },
-        {
-          "name": "Michael McCool"
-        },
-        {
-          "name": "Ryuichi Matsukura"
-        },
-        {
-          "name": "Sebastian Käbisch"
-        },
-        {
-          "name": "Tomoaki Mizushima"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
-      }
-    },
-    {
-      "id": "https://www.w3.org/TR/wot-discovery/",
-      "type": "TechArticle",
-      "name": "Web of Things (WoT) Discovery",
-      "url": "https://www.w3.org/TR/wot-discovery/",
-      "creator": [
-        {
-          "name": "Andrea Cimmino"
-        },
-        {
-          "name": "Michael McCool"
-        },
-        {
-          "name": "Farshid Tavakolizadeh"
-        },
-        {
-          "name": "Kunihiko Toumura"
-        }
-      ],
-      "publisher": {
-        "name": "W3C"
-      }
-    },
-    {
       "id": "https://www.rfc-editor.org/rfc/rfc8446",
       "type": "TechArticle",
       "name": "The Transport Layer Security (TLS) Protocol Version 1.3",
@@ -537,6 +488,55 @@ dd{margin-left:0}
       ],
       "publisher": {
         "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-discovery/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Discovery",
+      "url": "https://www.w3.org/TR/wot-discovery/",
+      "creator": [
+        {
+          "name": "Andrea Cimmino"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Farshid Tavakolizadeh"
+        },
+        {
+          "name": "Kunihiko Toumura"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/wot-profile/",
+      "type": "TechArticle",
+      "name": "Web of Things (WoT) Profile",
+      "url": "https://www.w3.org/TR/wot-profile/",
+      "creator": [
+        {
+          "name": "Michael Lagally"
+        },
+        {
+          "name": "Michael McCool"
+        },
+        {
+          "name": "Ryuichi Matsukura"
+        },
+        {
+          "name": "Sebastian Käbisch"
+        },
+        {
+          "name": "Tomoaki Mizushima"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
       }
     },
     {
@@ -1448,8 +1448,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2022-11-02T00:00:00.000Z",
-  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 02 November 2022"
+  "publishISODate": "2022-11-03T00:00:00.000Z",
+  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 03 November 2022"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-CR"></head>
 
@@ -1457,12 +1457,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Architecture 1.1</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#CR">W3C Candidate Recommendation Snapshot</a> <time class="dt-published" datetime="2022-11-02">02 November 2022</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#CR">W3C Candidate Recommendation Snapshot</a> <time class="dt-published" datetime="2022-11-03">03 November 2022</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2022/CR-wot-architecture11-20221102/">https://www.w3.org/TR/2022/CR-wot-architecture11-20221102/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2022/CR-wot-architecture11-20221103/">https://www.w3.org/TR/2022/CR-wot-architecture11-20221103/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>
@@ -1556,9 +1556,10 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       These sections are self contained, do not contain any assertion and other 
       specifications do not depend on these sections.</li>
       <li>Section 6 <a href="#sec-wot-architecture">Abstract WoT System Architecture</a>, 
-        section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
-        explain building blocks and architectural elements of the <abbr title="World Wide Web Consortium">W3C</abbr> WoT. 
-        These sections are normative and contain many assertions that are relevant for WoT implementations. </li>
+        explains architectural elements of the <abbr title="World Wide Web Consortium">W3C</abbr> WoT. 
+        This section is normative and contains assertions that are relevant for WoT implementations.</li>
+      <li>Section 7 <a href="#sec-building-blocks">WoT Building Blocks</a>,
+        explains building blocks of the <abbr title="World Wide Web Consortium">W3C</abbr> WoT.</li> 
       <li>Section 8 <a href="#sec-servient-implementation">Abstract Servient Architecture</a> describes
         the architecture of a <a href="#dfn-servient" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-servient-1">Servient</a>. It informatively describes how to implement a <a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-runtime-1">WoT Runtime</a> on a device.</li>
       <li>Section 9 <a href="#sec-deployment-scenario">Example WoT Deployments</a> 
@@ -2253,7 +2254,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       <dt>
         <dfn id="dfn-wot-profile" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">WoT Profile</dfn>
       </dt>
-      <dd>Synonym for <a href="#dfn-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-profile-1">Profile</a>.</dd>	    
+      <dd>Synonym for <a href="#dfn-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-profile-1">Profile</a></dd>	    
       <dt>
         <dfn id="dfn-wot-runtime" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">WoT Runtime</dfn>
       </dt>
@@ -4112,11 +4113,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     </section>
   </section>
 
-  <section id="sec-building-blocks"><div class="header-wrapper"><h2 id="x7-wot-building-blocks"><bdi class="secno">7. </bdi>WoT Building Blocks</h2><a class="self-link" href="#sec-building-blocks" aria-label="Permalink for Section 7."></a></div>
+  <section id="sec-building-blocks" class="informative"><div class="header-wrapper"><h2 id="x7-wot-building-blocks"><bdi class="secno">7. </bdi>WoT Building Blocks</h2><a class="self-link" href="#sec-building-blocks" aria-label="Permalink for Section 7."></a></div><p><em>This section is non-normative.</em></p>
     
-    <p>
-      <em>This section is normative.</em>
-    </p>
     <p> The Web of Things (WoT) building blocks allow the
       implementation of systems that conform with the abstract WoT
       Architecture. The specifics of these building blocks are
@@ -4413,17 +4411,15 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         </p>
         <ul>
         <li>
-        <span class="rfc2119-assertion" id="arch-discovery-no-metadata-in-introduction">
-        Any <a href="#dfn-wot-introduction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-introduction-3">introduction</a> mechanism used for <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-11">WoT Discovery</a> <em class="rfc2119">MUST NOT</em> 
+        Any <a href="#dfn-wot-introduction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-introduction-3">introduction</a> mechanism used for <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-11">WoT Discovery</a> must not
         provide metadata but instead should simply result in 
         one or more opaque URLs at which metadata
         may be accessed, if and only if the user can authenticate and 
-        has the appropriate authorization (access rights).</span>
+        has the appropriate authorization (access rights).
         </li>
         <li>
-        <span class="rfc2119-assertion" id="arch-discovery-no-metadata-in-introduction-urls">
-        <a href="#dfn-wot-introduction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-introduction-4">Introduction</a> URLs <em class="rfc2119">MUST NOT</em> themselves include any metadata,
-        e.g. a human-readable device type or name.</span>  
+        <a href="#dfn-wot-introduction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-introduction-4">Introduction</a> URLs must not themselves include any metadata,
+        e.g. a human-readable device type or name.  
         Randomly generated URLs are recommended.
         </li>
         </ul>
@@ -4448,10 +4444,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         <a href="#dfn-tdd" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-tdd-3">TDDs</a> also provide change notification mechanisms 
         to support secure distribution of
         <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-19">TD</a> updates to authorized consumers.
-        <span class="rfc2119-assertion" id="arch-discovery-metadata-after-authorization">
         Any <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-13">WoT Discovery</a> "exploration"
-        implementation <em class="rfc2119">MUST</em> only provide metadata and <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-20">TDs</a>
-        after appropriate best-practice authentication and authorization.</span>
+        implementation must only provide metadata and <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-20">TDs</a>
+        after appropriate best-practice authentication and authorization.
         Suitable best-practice security mechanisms for authentication and authorization for 
         different circumstances are discussed in [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-security" title="Web of Things (WoT) Security and Privacy Guidelines">WOT-SECURITY</a></cite>].  
         Suitable mechanisms for managing access controls and keys are also discussed
@@ -4479,15 +4474,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         The <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-14">Discovery</a> mechanisms defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">WOT-DISCOVERY</a></cite>] are not mandatory, but
         they are designed to meet the above requirements and their use will enhance 
         interoperability and usability.
-        <span class="rfc2119-assertion" id="arch-discovery-should-use-standard">Whenever
-        possible, the <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-15">Discovery</a> mechanisms defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">WOT-DISCOVERY</a></cite>]
-        <em class="rfc2119">SHOULD</em> be used to distribute <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-23">TDs</a>.</span>
         </p>
     </section>
 
     
 
-    <section id="sec-binding-templates" class="informative"><div class="header-wrapper"><h3 id="x7-5-wot-binding-templates"><bdi class="secno">7.5 </bdi>WoT Binding Templates</h3><a class="self-link" href="#sec-binding-templates" aria-label="Permalink for Section 7.5"></a></div><p><em>This section is non-normative.</em></p>
+    <section id="sec-binding-templates"><div class="header-wrapper"><h3 id="x7-5-wot-binding-templates"><bdi class="secno">7.5 </bdi>WoT Binding Templates</h3><a class="self-link" href="#sec-binding-templates" aria-label="Permalink for Section 7.5"></a></div>
       
 
 
@@ -4529,10 +4521,10 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       </figure>
       <p> <a href="#fig-binding-templates" class="fig-ref" title="From Binding Templates to Protocol Bindings">Figure <bdi class="figno">31</bdi></a> shows how <a href="#dfn-wot-binding-templates" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-binding-templates-6">Binding
           Templates</a> are used. Based on the protocol, media type or platform binding, 
-          a <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-24">TD</a> is created. The <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-consumer-54">Consumer</a> that is processing a <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-25">TD</a> 
+          a <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-23">TD</a> is created. The <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-consumer-54">Consumer</a> that is processing a <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-24">TD</a> 
           implements the required <a href="#dfn-wot-binding-templates" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-binding-templates-7">Binding Template</a> that is present in the TD by including a corresponding 
           protocol stack, media type encoder/decoder or platform stack and by configuring
-           the stack (or its messages) according to the information given in the <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-26">TD</a> such as 
+           the stack (or its messages) according to the information given in the <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-25">TD</a> such as 
 	  serialization format of the messages and header options.
       </p>
 
@@ -4553,11 +4545,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
             <li>
                 <b>Subprotocol</b>
                 <p>
-                  <span class="rfc2119-assertion" id="arch-binding-templates-known-subprotocol">
-                    <a href="#dfn-transport-protocol" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-transport-protocol-6">Transport protocols</a> <em class="rfc2119">MAY</em> have to use information provided by an extension mechanisms to interact successfully.</span>
-                  <span class="rfc2119-assertion" id="arch-binding-templates-subprotocol-explicit-declaration">
-                  Such <a href="#dfn-subprotocol" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-subprotocol-2">subprotocols</a> cannot be identified from the URI scheme alone and <em class="rfc2119">MUST</em> be declared explicitly
-                  using the <code>subprotocol</code> field inside forms.</span>
+                  <a href="#dfn-transport-protocol" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-transport-protocol-6">Transport protocols</a> may have to use information provided by an extension mechanisms to interact successfully.
+                  Such <a href="#dfn-subprotocol" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-subprotocol-2">subprotocols</a> cannot be identified from the URI scheme alone and must be declared explicitly
+                  using the <code>subprotocol</code> field inside forms.
                   Examples for HTTP are long polling [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6202" title="Known Issues and Best Practices for the Use of Long Polling and Streaming in Bidirectional HTTP">RFC6202</a></cite>] (<code>longpoll</code>) or 
                   Server-Sent Events [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] (<code>sse</code>).
                 </p>
@@ -4569,12 +4559,10 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
           <p>
             Representation formats (a.k.a. serializations) used for exchanging data can differ between protocols, 
             <a href="#dfn-iot-platform" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-iot-platform-5">IoT Platforms</a> and standards.
-            <span class="rfc2119-assertion" id="arch-binding-templates-media-type-parameters">
-            The media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>] identifies these formats, while media type parameters <em class="rfc2119">MAY</em> specify them further.</span>
-            <span class="rfc2119-assertion" id="arch-binding-templates-media-type-optional-parameters">
-            Forms <em class="rfc2119">MAY</em> contain the media type and optional parameters in additional form fields such as a content type 
+            The media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>] identifies these formats, while media type parameters may specify them further.
+            Forms may contain the media type and optional parameters in additional form fields such as a content type 
             field known from HTTP, which combines media type and its potential parameters
-            (e.g., <code>text/plain; charset=utf-8</code>).</span>
+            (e.g., <code>text/plain; charset=utf-8</code>).
           </p>
         </li>
         <li>
@@ -4585,7 +4573,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
             They can also contain specific payload structures on top of the media types that need to be accurately 
             incorporated into each message between the Thing and its Consumer.
             Both the protocol modification and payload representation specific to different platforms can be represented
-            in <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-27">TDs</a> using the best practices documented in binding templates for platforms and standards.
+            in <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-26">TDs</a> using the best practices documented in binding templates for platforms and standards.
           </p>
         </li>
       </ul>
@@ -4593,7 +4581,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     
 
-    <section id="sec-scripting-api" class="informative"><div class="header-wrapper"><h3 id="x7-6-wot-scripting-api"><bdi class="secno">7.6 </bdi>WoT Scripting API</h3><a class="self-link" href="#sec-scripting-api" aria-label="Permalink for Section 7.6"></a></div><p><em>This section is non-normative.</em></p>
+    <section id="sec-scripting-api"><div class="header-wrapper"><h3 id="x7-6-wot-scripting-api"><bdi class="secno">7.6 </bdi>WoT Scripting API</h3><a class="self-link" href="#sec-scripting-api" aria-label="Permalink for Section 7.6"></a></div>
       
       <p> The <a href="#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-scripting-api-3">WoT Scripting API</a> is an optional "convenience"
         building block of <abbr title="World Wide Web Consortium">W3C</abbr> WoT that eases IoT application
@@ -4639,7 +4627,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       <p> Security is a cross-cutting concern and should be
         considered in all aspects of system design. In the WoT
         architecture, security is supported by certain explicit
-        features, such as support for <a href="#dfn-public-security-metadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-public-security-metadata-3">Public Security Metadata</a> in <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-28">TDs</a>
+        features, such as support for <a href="#dfn-public-security-metadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-public-security-metadata-3">Public Security Metadata</a> in <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-27">TDs</a>
         and by separation of concerns in the design of the
         <a href="#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-scripting-api-8">WoT Scripting API</a>. The specification for each building
         block also includes a discussion of particular security
@@ -4789,7 +4777,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <section id="expose-consumed-thing"><div class="header-wrapper"><h3 id="x8-4-exposed-thing-and-consumed-thing-abstractions"><bdi class="secno">8.4 </bdi>Exposed Thing and Consumed Thing Abstractions</h3><a class="self-link" href="#expose-consumed-thing" aria-label="Permalink for Section 8.4"></a></div>
       
       <p>
-        The <a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-runtime-16">WoT Runtime</a> instantiates software representations of <a href="#dfn-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-thing-133">Things</a> based on their <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-29">TDs</a>.
+        The <a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-runtime-16">WoT Runtime</a> instantiates software representations of <a href="#dfn-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-thing-133">Things</a> based on their <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-28">TDs</a>.
         These software representations provide the interface towards the behavior implementation.
       </p>
       <p>
@@ -4804,12 +4792,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         to be accessed using a communication protocol.
         <a href="#dfn-consumed-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-consumed-thing-12">Consumed Things</a> are proxy objects or stubs.
         The behavior implementation is restricted to reading their metadata and activating their <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-interaction-affordance-31">Interaction
-          Affordances</a> as described in the corresponding <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-30">TD</a>.
+          Affordances</a> as described in the corresponding <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-29">TD</a>.
         <a href="#dfn-consumed-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-consumed-thing-13">Consumed Things</a> can also represent system features such as local hardware or devices behind proprietary
         or legacy communication protocols.
         In this case, the <a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-runtime-17">WoT Runtime</a> must provide the necessary adaptation between system API and <a href="#dfn-consumed-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-consumed-thing-14">Consumed
           Thing</a>.
-        Furthermore, it must provide corresponding <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-31">TDs</a> and make them available to the behavior implementation,
+        Furthermore, it must provide corresponding <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-30">TDs</a> and make them available to the behavior implementation,
         for instance, by extending whatever discovery mechanism is provided by the <a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-runtime-18">WoT Runtime</a> through the
         application-facing API
         (e.g., the <code>discover()</code> method defined in the <a href="#dfn-wot-scripting-api" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-scripting-api-19">WoT Scripting API</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-scripting-api" title="Web of Things (WoT) Scripting API">WOT-SCRIPTING-API</a></cite>]).
@@ -4915,7 +4903,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       <p>
         Furthermore, devices or services unaware of <abbr title="World Wide Web Consortium">W3C</abbr> WoT can still be consumed,
         when it is possible to provide a well-formed <a href="#dfn-wot-thing-description" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-thing-description-23">WoT Thing Description</a> for them.
-        In this case, the <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-32">TD</a> describes a <a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-11">WoT Interface</a> of a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-thing-139">Thing</a> that has a black-box
+        In this case, the <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-31">TD</a> describes a <a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-11">WoT Interface</a> of a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-thing-139">Thing</a> that has a black-box
         implementation.
       </p>
       <section id="native-impl"><div class="header-wrapper"><h4 id="x8-8-1-native-wot-api"><bdi class="secno">8.8.1 </bdi>Native WoT API</h4><a class="self-link" href="#native-impl" aria-label="Permalink for Section 8.8.1"></a></div>
@@ -5015,7 +5003,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         The concrete discovery mechanism depends on the individual deployment scenario:
         It could be provided by a management system such as a <a href="#dfn-wot-thing-description-directory" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-thing-description-directory-11">Thing Description Directory</a>,
         a discovery protocol, through static assignment, etc.  As discussed
-        elsewhere, use of the <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-16">Discovery</a> mechanisms defined in
+        elsewhere, use of the <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-15">Discovery</a> mechanisms defined in
         [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">WOT-DISCOVERY</a></cite>] is recommended whenever possible.
       </p>
       <p>However, it should be noted that TDs describing
@@ -5431,7 +5419,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 	  <em class="rfc2119">SHOULD</em> be established based on separately managed <a href="#dfn-private-security-data" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-private-security-data-7">Private Security Data</a>.</span>
 	  <span class="rfc2119-assertion" id="arch-security-consideration-no-private-security-data">
           <a href="#dfn-producer" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-producer-1">Producers</a> of TDs <em class="rfc2119">MUST</em> ensure that no <a href="#dfn-private-security-data" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-private-security-data-8">Private
-          Security Data</a> is included in <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-33">TDs</a>.</span>
+          Security Data</a> is included in <a href="#dfn-td" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-td-32">TDs</a>.</span>
 	  </dd>
         </dl>
       </section>
@@ -5882,7 +5870,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 	    <span class="rfc2119-assertion" id="arch-privacy-consideration-dist-td-auth"> 
 	    Distribution mechanisms for TDs <em class="rfc2119">SHOULD</em> ensure they are 
 	    only provided to authorized Consumers.</span>
-	    Note that the <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-17">WoT Discovery</a> mechanism is designed to address these
+	    Note that the <a href="#dfn-wot-discovery" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-discovery-16">WoT Discovery</a> mechanism is designed to address these
 	    specific issues, as long as it is used with authentication and access
 	    controls on exploration services.
 	    
@@ -6429,15 +6417,15 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">SHO
   </li><li>
     <a href="#ref-for-dfn-wot-discovery-5" title="§ 7. WoT Building Blocks">§ 7. WoT Building Blocks</a> 
   </li><li>
-    <a href="#ref-for-dfn-wot-discovery-6" title="§ 7.4 WoT Discovery">§ 7.4 WoT Discovery</a> <a href="#ref-for-dfn-wot-discovery-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-wot-discovery-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-wot-discovery-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-wot-discovery-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-wot-discovery-14" title="Reference 6">(6)</a> <a href="#ref-for-dfn-wot-discovery-15" title="Reference 7">(7)</a> 
+    <a href="#ref-for-dfn-wot-discovery-6" title="§ 7.4 WoT Discovery">§ 7.4 WoT Discovery</a> <a href="#ref-for-dfn-wot-discovery-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-wot-discovery-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-wot-discovery-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-wot-discovery-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-wot-discovery-14" title="Reference 6">(6)</a> 
   </li><li>
     <a href="#ref-for-dfn-wot-discovery-11" title="§ 7.4.1 Introduction Mechanisms">§ 7.4.1 Introduction Mechanisms</a> 
   </li><li>
     <a href="#ref-for-dfn-wot-discovery-12" title="§ 7.4.2 Exploration Mechanisms">§ 7.4.2 Exploration Mechanisms</a> <a href="#ref-for-dfn-wot-discovery-13" title="Reference 2">(2)</a> 
   </li><li>
-    <a href="#ref-for-dfn-wot-discovery-16" title="§ 9.1 Thing and Consumer Roles">§ 9.1 Thing and Consumer Roles</a> 
+    <a href="#ref-for-dfn-wot-discovery-15" title="§ 9.1 Thing and Consumer Roles">§ 9.1 Thing and Consumer Roles</a> 
   </li><li>
-    <a href="#ref-for-dfn-wot-discovery-17" title="§ 11.1.1 Thing Description Personally Identifiable Information Risk">§ 11.1.1 Thing Description Personally Identifiable Information Risk</a> 
+    <a href="#ref-for-dfn-wot-discovery-16" title="§ 11.1.1 Thing Description Personally Identifiable Information Risk">§ 11.1.1 Thing Description Personally Identifiable Information Risk</a> 
   </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-wot-discoverer" aria-label="Links in this document to definition: Discoverer">
@@ -7063,19 +7051,19 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">SHO
   </li><li>
     <a href="#ref-for-dfn-td-8" title="§ 7.1 WoT Thing Description">§ 7.1 WoT Thing Description</a> <a href="#ref-for-dfn-td-9" title="Reference 2">(2)</a> <a href="#ref-for-dfn-td-10" title="Reference 3">(3)</a> <a href="#ref-for-dfn-td-11" title="Reference 4">(4)</a> <a href="#ref-for-dfn-td-12" title="Reference 5">(5)</a> <a href="#ref-for-dfn-td-13" title="Reference 6">(6)</a> <a href="#ref-for-dfn-td-14" title="Reference 7">(7)</a> <a href="#ref-for-dfn-td-15" title="Reference 8">(8)</a> <a href="#ref-for-dfn-td-16" title="Reference 9">(9)</a> 
   </li><li>
-    <a href="#ref-for-dfn-td-17" title="§ 7.4 WoT Discovery">§ 7.4 WoT Discovery</a> <a href="#ref-for-dfn-td-23" title="Reference 2">(2)</a> 
+    <a href="#ref-for-dfn-td-17" title="§ 7.4 WoT Discovery">§ 7.4 WoT Discovery</a> 
   </li><li>
     <a href="#ref-for-dfn-td-18" title="§ 7.4.2 Exploration Mechanisms">§ 7.4.2 Exploration Mechanisms</a> <a href="#ref-for-dfn-td-19" title="Reference 2">(2)</a> <a href="#ref-for-dfn-td-20" title="Reference 3">(3)</a> <a href="#ref-for-dfn-td-21" title="Reference 4">(4)</a> <a href="#ref-for-dfn-td-22" title="Reference 5">(5)</a> 
   </li><li>
-    <a href="#ref-for-dfn-td-24" title="§ 7.5 WoT Binding Templates">§ 7.5 WoT Binding Templates</a> <a href="#ref-for-dfn-td-25" title="Reference 2">(2)</a> <a href="#ref-for-dfn-td-26" title="Reference 3">(3)</a> <a href="#ref-for-dfn-td-27" title="Reference 4">(4)</a> 
+    <a href="#ref-for-dfn-td-23" title="§ 7.5 WoT Binding Templates">§ 7.5 WoT Binding Templates</a> <a href="#ref-for-dfn-td-24" title="Reference 2">(2)</a> <a href="#ref-for-dfn-td-25" title="Reference 3">(3)</a> <a href="#ref-for-dfn-td-26" title="Reference 4">(4)</a> 
   </li><li>
-    <a href="#ref-for-dfn-td-28" title="§ 7.7 WoT Security and Privacy Guidelines">§ 7.7 WoT Security and Privacy Guidelines</a> 
+    <a href="#ref-for-dfn-td-27" title="§ 7.7 WoT Security and Privacy Guidelines">§ 7.7 WoT Security and Privacy Guidelines</a> 
   </li><li>
-    <a href="#ref-for-dfn-td-29" title="§ 8.4 Exposed Thing and Consumed Thing Abstractions">§ 8.4 Exposed Thing and Consumed Thing Abstractions</a> <a href="#ref-for-dfn-td-30" title="Reference 2">(2)</a> <a href="#ref-for-dfn-td-31" title="Reference 3">(3)</a> 
+    <a href="#ref-for-dfn-td-28" title="§ 8.4 Exposed Thing and Consumed Thing Abstractions">§ 8.4 Exposed Thing and Consumed Thing Abstractions</a> <a href="#ref-for-dfn-td-29" title="Reference 2">(2)</a> <a href="#ref-for-dfn-td-30" title="Reference 3">(3)</a> 
   </li><li>
-    <a href="#ref-for-dfn-td-32" title="§ 8.8 Alternative Servient and WoT Implementations">§ 8.8 Alternative Servient and WoT Implementations</a> 
+    <a href="#ref-for-dfn-td-31" title="§ 8.8 Alternative Servient and WoT Implementations">§ 8.8 Alternative Servient and WoT Implementations</a> 
   </li><li>
-    <a href="#ref-for-dfn-td-33" title="§ 10.1.1 Thing Description Private Security Data Risk">§ 10.1.1 Thing Description Private Security Data Risk</a> 
+    <a href="#ref-for-dfn-td-32" title="§ 10.1.1 Thing Description Private Security Data Risk">§ 10.1.1 Thing Description Private Security Data Risk</a> 
   </li>
   </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-tdd" aria-label="Links in this document to definition: TDD">

--- a/testing/report11.html
+++ b/testing/report11.html
@@ -121,7 +121,7 @@ pre.example {
     DRAFT Implementation Report
   </h1>
   <p>
-    <b>Version</b>: 1 Nov 2022
+    <b>Version</b>: 3 Nov 2022
   </p>
   <p>
     <b>Editors</b>:<br>


### PR DESCRIPTION
As agreed, this PR downgrades sections 7.4 and 7.5 to informative sections, removing any assertions.  This allows the entirely of section 7 to be informative as previously decided.  It also makes a few other necessary changes consistent with this goal.  Details:
- Small change to the abstract that outlines the sections, which previously said both section 6 and section 7 were normative.   Now it only says section 6 is normative.  
     - NOTE: a section outline does NOT belong in the abstract, for the same reason we can't have references in the abstract: the abstract needs to be self-contained.  The section outline in particular has hyperlinks which would be broken if the abstract is used out of content.
     - I would prefer we delete this list, or move it to the intro (although the intro ALSO has an outline, so it may be redundant.)  As this is an editorial change, however, we can do it post-CR.  
     - I have created an issue (and a PR) so we can follow up: https://github.com/w3c/wot-architecture/issues/874 and https://github.com/w3c/wot-architecture/pull/876
- Downgrade of normative references to WOT-PROFILES and WOT-DISCOVERY to informative references (this is consistent with other building block references in section 7 and is also necessary to avoid ReSpec warnings).
- Downgrade or remove assertions in section 7.4.  All but the last assertion were downgraded.  The last assertion, which was on the use of the Discovery spec as a whole, was removed (it's optional anyway).  
- Downgrade assertions in section 7.5.  Generally, this only involved decapitalizing key words and removing spans.  However, there was also a normative reference to RFC2046 that was downgraded to an informative reference (can't have an normative reference in an informative section)
- Updated the CR static version in publication/ver11/3-cr/*.html to be consistent (note: you can view Overview.html if you want to see the assertion highlighting, as this version inlines the CSS file)
- Updated the IR (to remove the deleted assertions)

I also did an actual search in the document for any spans in section 7 that we might have overlooked.  I confirmed that there are no assertions in section 7 after the changes above.  I also checked that there are no ReSpec warnings or errors.  I also checked that removal of these assertions does not change the at-risk section in the sotd; it does not, as none of the removed assertions were at risk.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/873.html" title="Last updated on Nov 3, 2022, 1:28 PM UTC (44c4c35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/873/1c7ba10...mmccool:44c4c35.html" title="Last updated on Nov 3, 2022, 1:28 PM UTC (44c4c35)">Diff</a>