### PR TITLE
Provide CR exit statment in sotd section

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,17 @@
       It also references the other implementation
       reports for the various WoT building blocks.
     </p>
-
+ <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
+ <p>The Web of Things Working Group intends to submit this document
+        for consideration as a <abbr title=
+        "World Wide Web Consortium">W3C</abbr> Proposed Recommendation
+        after at least the minimum CR review period has passed. However,
+        before PR transition is requested, any features or assertions
+        currently marked as at-risk that did not appear in the Architecture 1.0
+        specification and do not have at least two implementations at that
+        time will either be removed or converted into informative
+        statements, as appropriate. 
+    </p>
   </section>
   <section id="introduction" class="informative">
     <h1>Introduction</h1>

--- a/index.html
+++ b/index.html
@@ -325,7 +325,6 @@
       It also references the other implementation
       reports for the various WoT building blocks.
     </p>
- <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
  <p>The Web of Things Working Group intends to submit this document
         for consideration as a <abbr title=
         "World Wide Web Consortium">W3C</abbr> Proposed Recommendation
@@ -336,6 +335,7 @@
         time will either be removed or converted into informative
         statements, as appropriate. 
     </p>
+  <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
   </section>
   <section id="introduction" class="informative">
     <h1>Introduction</h1>


### PR DESCRIPTION
this is required for the CR request https://github.com/w3c/transitions/issues/474


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/878.html" title="Last updated on Nov 16, 2022, 12:59 PM UTC (f55abaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/878/5f788cc...f55abaf.html" title="Last updated on Nov 16, 2022, 12:59 PM UTC (f55abaf)">Diff</a>