### PR TITLE
Fix broken link for respec

### DIFF
--- a/index.html
+++ b/index.html
@@ -4662,7 +4662,7 @@ Services returning Thing Descriptions with immutable IDs SHOULD use some form of
     <h1>Recent Specification Changes</h1>
     <h2 id="changes-from-wd-2022-09-07">Changes from the WD published September 7, 2022</h2>
     <ul>
-      <li>Modify <a href="#sec-wot-building-blocks">Section 7, WoT Building Blocks</a> so that it is informative.</li>
+      <li>Modify <a href="#sec-building-blocks">Section 7, WoT Building Blocks</a> so that it is informative.</li>
       <li>Add terminology entries for Profile, System, and Directory.</li>
       <li>Updates to affiliation of Matthias Kovatsch (as a former editor).</li>
       <li>Add/update references to the WoT Use Cases and Requirements [[WOT-USE-CASES-REQUIREMENTS]] document.</li>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/879.html" title="Last updated on Nov 21, 2022, 2:53 PM UTC (c3b05fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/879/3c0e8b8...c3b05fc.html" title="Last updated on Nov 21, 2022, 2:53 PM UTC (c3b05fc)">Diff</a>