### PR TITLE
fix binding reference in change log

### DIFF
--- a/index.html
+++ b/index.html
@@ -4677,7 +4677,7 @@ Services returning Thing Descriptions with immutable IDs SHOULD use some form of
       <li>Lifecycle section reworked; removal of separate "Information Lifecycle" section.</li>
       <li>Reference and discuss new WoT building block and document: WoT Discovery [[WOT-DISCOVERY]]</li>
       <li>Update discussion of WoT Profiles [[WOT-PROFILE]]</li>
-      <li>Update discussion of WoT Binding Templates [[WOT-BINDING-TEMPLATES]]</li>
+      <li>Update discussion of WoT Binding Templates [[?WOT-BINDING-TEMPLATES]]</li>
       <li>Rename "System Topologies (Horizontals)" to "Common Deployment Patterns".</li>
       <li>Rename "Application Domains (Verticals)" to "Application Domains".</li>
       <li>New or revised deployment patterns:


### PR DESCRIPTION
solves binding reference issue as mentioned here https://github.com/w3c/transitions/issues/474#issuecomment-1320565680

The change log section includes a normative reference to the binding template document, however, which should be a non-normative reference. This PR fixes this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/880.html" title="Last updated on Nov 23, 2022, 10:18 AM UTC (01a0836)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/880/3c0e8b8...01a0836.html" title="Last updated on Nov 23, 2022, 10:18 AM UTC (01a0836)">Diff</a>