### PR TITLE
Resolve arch-security-consideration-use-psk

### DIFF
--- a/index.html
+++ b/index.html
@@ -4356,17 +4356,23 @@
 	In the case of implicit access control via access to a common network
 	a segmented network SHOULD be used.</span>
 	For example, in the home environment,
-	a separate WiFi network can be used for IoT devices, and routers
+	a separate network can be used for IoT devices.
+<!-- following not strictly true as guest networks often do not allow inter-device communication
+  , and routers
 	often provide a "guest" network that can be used for this purpose.
-	<span class="rfc2119-assertion" id="arch-security-consideration-use-psk">
+-->
+	<!-- <span class="rfc2119-assertion" id="arch-security-consideration-use-psk"> -->
 	In commercial and industrial environments, 
-	explicit installation of pre-shared
-	keys SHOULD be used to allow browsers to access local services
-	while using TLS.</span>
-	Using a single key for a large number of services is
-	equivalent to the "implicit access" situation above.  However, once TLS is
-	enabled other security mechanisms that assume secure transport
+	explicit installation of <!-- pre-shared
+	keys --> certificates should be used to allow browsers to access local services
+	while using TLS.
+  <!-- </span> -->
+  Certificates support secure authentication and are required to enable TLS.
+  Once TLS is enabled other security mechanisms that assume secure transport, 
+  such as API keys or passwords,
 	can be used to provide fine-grained access control.
+	Note that using a single key for a large number of services is
+	equivalent to the "implicit access" situation above.  
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
Resolves #900.
Resolves #908 

- Remove at-risk assertion arch-security-consideration-use-psk
- Keep statement, but downgrade (SHOULD -> should) to an informative statement
- Address Issue #900 by using "certificates" instead of "pre-shared keys"
- Edit some of the following text to more clearly differentiate between the roles of certificates (which prove identity) and other security materials (like API keys or passwords) that are used for access control.
- Since it was an adjacent issue, also resolve #908 about guest networks


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/909.html" title="Last updated on May 17, 2023, 5:20 PM UTC (10e9df5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/909/476a18f...mmccool:10e9df5.html" title="Last updated on May 17, 2023, 5:20 PM UTC (10e9df5)">Diff</a>