### PR TITLE
Resolve arch-security-consideration-dtls-1-3

### DIFF
--- a/index.html
+++ b/index.html
@@ -4468,7 +4468,7 @@
           -->
             When secure transport over UDP is appropriate,
             then at least DTLS 1.3 [[RFC9147]]
-            should be used.
+            is recommended, if possible.
           <!-- </span> -->
           <span class="rfc2119-assertion" 
               id="arch-security-consideration-dtls-1-2">

--- a/index.html
+++ b/index.html
@@ -4460,11 +4460,16 @@
             but secure transport over TCP is appropriate,
             TLS 1.2 [[RFC5246]]
             MAY be used.</span>
-          <span class="rfc2119-assertion" 
-              id="arch-security-consideration-dtls-1-3">
+          <!-- <span class="rfc2119-assertion" 
+              id="arch-security-consideration-dtls-1-3"> 
+            This was downgraded from an assertion due to lack of testing
+            (problem with availablity of libraries).  However, it is still
+            a good idea to use DTLS 1.3 when available.
+          -->
             When secure transport over UDP is appropriate,
             then at least DTLS 1.3 [[RFC9147]]
-            SHOULD be used.</span>
+            should be used.
+          <!-- </span> -->
           <span class="rfc2119-assertion" 
               id="arch-security-consideration-dtls-1-2">
             If DTLS 1.3 cannot be used for compatibility reasons


### PR DESCRIPTION
Resolves #903
- Remove at-risk assertion arch-security-consideration-dtls-1-3
- Keep statement, but downgrade (SHOULD -> should) to an informative statement
- Nothing else changed.  Because of parallel structure however this looks a little like a mistake, but it is technically correct.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/910.html" title="Last updated on May 18, 2023, 10:20 AM UTC (55916c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/910/476a18f...mmccool:55916c4.html" title="Last updated on May 18, 2023, 10:20 AM UTC (55916c4)">Diff</a>