### PR TITLE
Resolve arch-security-consideration-hal-refuse-unsafe

### DIFF
--- a/index.html
+++ b/index.html
@@ -4229,11 +4229,19 @@
             implementation SHOULD provide a hardware
             abstraction layer for accessing the native
             device interfaces.</span>
-	    <span class="rfc2119-assertion" id="arch-security-consideration-hal-refuse-unsafe">
+      Hardware abstraction layers, or HALs, mediate the interaction between the 
+      application and the hardware and can be as simple as a software library,
+      although more sophisticated implementations may be implemented as drivers
+      accessible through system calls or supported by hypervisors.  The more 
+      sophisticated versions of HALs can prevent applications from bypassing them.
+	    <!-- <span class="rfc2119-assertion" id="arch-security-consideration-hal-refuse-unsafe"> -->
 	    Hardware abstraction
-            layers SHOULD refuse to execute commands that
+            layers should refuse to execute commands that
             might put the device (or environment) to an
-            unsafe state.</span>
+            unsafe state.<!-- </span> -->
+      Such "software interlocks" should not be the only mechanism preventing 
+      a system from entering an unsafe state.  Ideally, multiple layered safety
+      controls should be used, including both software and hardware interlocks.
 	    Additionally, in order to reduce
             the damage to a physical WoT device in cases a
             script gets compromised, it is important to

--- a/index.html
+++ b/index.html
@@ -4233,7 +4233,7 @@
       application and the hardware and can be as simple as a software library,
       although more sophisticated implementations may be implemented as drivers
       accessible through system calls or supported by hypervisors.  The more 
-      sophisticated versions of HALs can prevent applications from bypassing them.
+      sophisticated versions of hardware abstraction layers can prevent applications from bypassing them.
 	    <!-- <span class="rfc2119-assertion" id="arch-security-consideration-hal-refuse-unsafe"> -->
 	    Hardware abstraction
             layers should refuse to execute commands that

--- a/index.html
+++ b/index.html
@@ -4219,21 +4219,30 @@
         </p>
         <dl>
           <dt>Mitigation:</dt>
-          <dd>
+          <dd><p>
+	    In order to reduce
+            the damage to a physical WoT device in cases a
+            script gets compromised, it is important to
+            minimize the number of interfaces that are
+            exposed or accessible to a particular script
+            based on its functionality.
 	    <span class="rfc2119-assertion" id="arch-security-consideration-avoid-direct">
             The <a>WoT Runtime</a> SHOULD NOT directly
             expose native device interfaces to the
             script developers.</span>
+		  </p><p>
+      Hardware abstraction layers can provide an additional level of protection.
+      Hardware abstraction layers are software components that mediate the interaction between the 
+      application and the hardware and can be as simple as a software library,
+      although more sophisticated implementations may be implemented as drivers
+      accessible through system calls or supported by hypervisors.  The more 
+      sophisticated versions of hardware abstraction layers can prevent applications from bypassing them.
 	    <span class="rfc2119-assertion" id="arch-security-consideration-use-hal">
 	    A <a>WoT Runtime</a>
             implementation SHOULD provide a hardware
             abstraction layer for accessing the native
             device interfaces.</span>
-      Hardware abstraction layers mediate the interaction between the 
-      application and the hardware and can be as simple as a software library,
-      although more sophisticated implementations may be implemented as drivers
-      accessible through system calls or supported by hypervisors.  The more 
-      sophisticated versions of hardware abstraction layers can prevent applications from bypassing them.
+
 	    <!-- <span class="rfc2119-assertion" id="arch-security-consideration-hal-refuse-unsafe"> -->
 	    Hardware abstraction
             layers should refuse to execute commands that
@@ -4242,12 +4251,7 @@
       Such "software interlocks" should not be the only mechanism preventing 
       a system from entering an unsafe state.  Ideally, multiple layered safety
       controls should be used, including both software and hardware interlocks.
-	    Additionally, in order to reduce
-            the damage to a physical WoT device in cases a
-            script gets compromised, it is important to
-            minimize the number of interfaces that are
-            exposed or accessible to a particular script
-            based on its functionality.
+	</p>
           </dd>
         </dl>
       </section>

--- a/index.html
+++ b/index.html
@@ -4229,7 +4229,7 @@
             implementation SHOULD provide a hardware
             abstraction layer for accessing the native
             device interfaces.</span>
-      Hardware abstraction layers, or HALs, mediate the interaction between the 
+      Hardware abstraction layers mediate the interaction between the 
       application and the hardware and can be as simple as a software library,
       although more sophisticated implementations may be implemented as drivers
       accessible through system calls or supported by hypervisors.  The more 


### PR DESCRIPTION
Resolves #905
- Remove at-risk assertion arch-security-consideration-hal-refuse-unsafe
- Keep statement, but downgrade (SHOULD -> should) to an informative statement
- Add informative text explaining what a HAL is and mentioning some implementation options (addresses issue #905)
- Add informative text stating that HAL-based software interlocks should not be the only safety measure


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/911.html" title="Last updated on May 18, 2023, 10:36 AM UTC (43ff2d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/911/476a18f...mmccool:43ff2d9.html" title="Last updated on May 18, 2023, 10:36 AM UTC (43ff2d9)">Diff</a>