### PR TITLE
Uplevel Profile Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2923,10 +2923,14 @@
 
     <section id="wot-profiles">
       <h3>Profiles</h3>
+      <p class="note">
+        Currently, the <a>WoT Profile</a> specification has only been published 
+        as a Working Draft.
+      </p>
       <p>
-      The <a>WoT Profile</a> Specification [[?WOT-PROFILE]] defines Profiles, 
+      The <a>WoT Profile</a> Specification [[?WOT-PROFILE]] defines Profiles 
       that enable <em>out of the box interoperability</em> among things 
-      and devices. Out of the box interoperability implies, 
+      and devices. Out of the box interoperability implies
       that devices can be integrated into various application 
       scenarios without deep level adaptations. 
       Typically only minor configuration operations are necessary 
@@ -2934,6 +2938,7 @@
       device in a certain scenario. 
       These actions can be done by anyone without specific training.
       </p>
+<!--
       <p>
         The HTTP Baseline Profile defines a mapping to
         HTTP(S).
@@ -2948,10 +2953,10 @@
         These profiles can be used stand alone, or a device can implement a 
         combination of them.
         
-        It is envisioned, that other profiles will be defined in the future,
+        It is envisioned that other profiles will be defined in the future,
         that contain mappings to other protocols.
       </p>
-
+-->
       <section>
         <h3 id="profile-description-methodology">Profiling Methodology</h3>
         <p>
@@ -3029,7 +3034,7 @@
   
         <figure id="WoT-Profiles">
           <img src="images/profiles/WoTProfiles.png" class="wot-profiles" alt="WoT Profiles" />
-          <figcaption>WoT Baseline Profile - Other Profiles</figcaption>
+          <figcaption>Profile architecture</figcaption>
         </figure>
       </section>
     </section>


### PR DESCRIPTION
Resolves #804 
Uplevel profile section - avoid mentioning specific profiles
- Comment out section that mentions HTTP Baseline Profile, SSE Profile, etc - not yet decided.
- Add Note that WoT Profiles is still a Working Draft.
- Change Image caption to just "Profile architecture" so it does not seem like we are defining the term "WoT Baseline" as a thing - "a baseline profile" is used only as a generic category in the text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/pull/917.html" title="Last updated on May 25, 2023, 10:32 AM UTC (a961865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/917/9744a3f...a961865.html" title="Last updated on May 25, 2023, 10:32 AM UTC (a961865)">Diff</a>