### PR TITLE
REC Preparation v2

### DIFF
--- a/errata/v11.md
+++ b/errata/v11.md
@@ -1,5 +1,0 @@
-# WoT Architecture v11 Errata
-This file will contain errata for the WoT Architecture 1.1 W3C Recommendation
-published in 2023.
-
-There are currently no errata.

--- a/errata11.html
+++ b/errata11.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+  <!--
+    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
+    form 'w3c/XXX', although there are groups that have their own owner for their repository.
+  -->
+  <head data-githubrepo="w3c/wot-architecture">
+    <meta charset="UTF-8">
+    <title>Open Errata for the Web of Things (WoT) Architecture 1.1 Specification</title>
+    <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
+    <script src="https://www.w3.org/scripts/jquery/1.11/jquery.min.js"></script>
+    <script src="https://w3c.github.io/display_errata/assets/moment.min.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
+    <script src="https://www.w3.org/scripts/underscore/1.8/underscore-min.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
+
+    <style type="text/css">
+      .todo {
+        background-color: yellow
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <p class="banner"><a accesskey="W" href="/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
+      <br />
+      <h1 class="title">Open Errata for the Web of Things (WoT) Architecture 1.1 Specification</h1>
+      <dl>
+        <dt>Latest errata update:</dt>
+        <dd><span id="date"></span></dd>
+        <dt>Number of recorded errata:</dt>
+        <dd><span id="number"></span></dd>
+        <dt>Link to all errata:</dt>
+        <dd><span id="errata_link"></span></dd>
+      </dl>
+
+      <section data-notoc>
+        <h1>How to Submit an Erratum?</h1>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-architecture/issues/">issue list for the WoT Architecture GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <ul>
+           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
+           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
+          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s) (such as a pull request in <a href='https://github.com/web-platform-tests/wpt'>web-platform-tests</a>), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+      </ul>
+
+        <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
+
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
+      </section>
+    </header>
+
+    <div class="toc" id="toc"></div>
+
+    <main>
+      <!-- The data-erratalabel should include one label that filters the errata -->
+      <section data-nolabel>
+        <h1>Open Errata on the "WoT Architecture 1.1" Recommendation</h1>
+        <dl>
+          <dt>Latest Published Version:</dt>
+          <dd><a href="https://www.w3.org/TR/wot-thing-description/">https://www.w3.org/TR/wot-architecture/</a></dd>
+          <dt>Editor’s draft:</dt>
+          <dd><a href="https://w3c.github.io/wot-thing-description/">https://w3c.github.io/wot-architecture/</a></dd>
+          <dt>Latest Publication Date:</dt>
+          <dd>2 April 2020</dd>
+          <!-- TODO: Fix the date -->
+      </dl>
+        <section id="first">
+          <h2>Substantive Issues</h2>
+        </section>
+        <section id="last">
+          <h2>Editorial Issues</h2>
+        </section>
+      </section>
+    </main>
+
+    <footer>
+      <address><a href="mailto:ashimura@w3.org" class=''>Kaz Ashimura</a>, &lt;ashimura@w3.org&gt;, (W3C)</address>
+      <p class="copyright"><a href="/Consortium/Legal/ipr-notice#Copyright" rel="Copyright">Copyright</a> © 2020 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a> <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
           date: "13 June 2019"
         },
         "IEC-FOTF": {
-          href: "https://www.iec.ch/basecamp/factory-future/",
+          href: "https://www.iec.ch/basecamp/factory-future",
           title: "Factory of the future",
           publisher: "IEC",
           date: "October 2015"
@@ -4902,8 +4902,8 @@ Services returning Thing Descriptions with immutable IDs SHOULD use some form of
            regarding the concept of "Web of Things" that started as an academic
            initiative in the form of publications such as [[?WOT-PIONEERS-1]] [[?WOT-PIONEERS-2]]
            [[?WOT-PIONEERS-3]] [[?WOT-PIONEERS-4]] and, starting
-           in 2010, a yearly <a href="https://webofthings.org/events/wot/">
-           International Workshop on the Web of Things</a>.</p>
+           in 2010, an
+           <i>International Workshop on the Web of Things</i>.</p>
            <p>Finally, special thanks to Joerg Heuer for leading the WoT IG for 2 years
             from its inception and guiding the group to come up with the concept of
             WoT building blocks including the Thing Description.</p>

--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
       }
     };
   </script>
-  <style type="text/css">
+  <style>
     a[href].internalDFN {
       color: inherit;
       border-bottom: 1px solid #99c;

--- a/publication/ver11/5-rec/Overview.html
+++ b/publication/ver11/5-rec/Overview.html
@@ -4,7 +4,7 @@
 <meta name="generator" content=
 "HTML Tidy for HTML5 for Linux version 5.6.0">
 <meta charset="utf-8">
-<meta name="generator" content="ReSpec 34.1.8">
+<meta name="generator" content="ReSpec 34.2.0">
 <meta name="viewport" content=
 "width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
@@ -151,7 +151,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2023/software-license",
-  "datePublished": "2023-10-03",
+  "datePublished": "2023-10-24",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -667,10 +667,10 @@ dd{margin-left:0}
       }
     },
     {
-      "id": "https://www.iec.ch/basecamp/factory-future/",
+      "id": "https://www.iec.ch/basecamp/factory-future",
       "type": "TechArticle",
       "name": "Factory of the future",
-      "url": "https://www.iec.ch/basecamp/factory-future/",
+      "url": "https://www.iec.ch/basecamp/factory-future",
       "publisher": {
         "name": "IEC"
       }
@@ -1232,7 +1232,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "date": "13 June 2019"
     },
     "IEC-FOTF": {
-      "href": "https://www.iec.ch/basecamp/factory-future/",
+      "href": "https://www.iec.ch/basecamp/factory-future",
       "title": "Factory of the future",
       "publisher": "IEC",
       "date": "October 2015",
@@ -1454,8 +1454,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2023-10-03T00:00:00.000Z",
-  "generatedSubtitle": "W3C Recommendation 03 October 2023"
+  "publishISODate": "2023-10-24T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 24 October 2023"
 }
 </script>
 <link rel="stylesheet" href=
@@ -1471,14 +1471,14 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 1.1</h1>
 <p id="w3c-state"><a href=
 "https://www.w3.org/standards/types#REC">W3C Recommendation</a>
-<time class="dt-published" datetime="2023-10-03">03 October
+<time class="dt-published" datetime="2023-10-24">24 October
 2023</time></p>
 <details open="">
 <summary>More details about this document</summary>
 <dl>
 <dt>This version:</dt>
 <dd><a class="u-url" href=
-"https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/</a></dd>
+"https://www.w3.org/TR/2023/REC-wot-architecture11-20231024/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231024/</a></dd>
 <dt>Latest published version:</dt>
 <dd><a href=
 "https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a></dd>
@@ -8594,9 +8594,8 @@ academic initiative in the form of publications such as
 [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-pioneers-4" title=
 "A Resource Oriented Architecture for the Web of Things">WOT-PIONEERS-4</a></cite>]
-and, starting in 2010, a yearly <a href=
-"https://webofthings.org/events/wot/">International Workshop on the
-Web of Things</a>.</p>
+and, starting in 2010, an <i>International Workshop on the Web of
+Things</i>.</p>
 <p>Finally, special thanks to Joerg Heuer for leading the WoT IG
 for 2 years from its inception and guiding the group to come up
 with the concept of WoT building blocks including the Thing
@@ -8767,9 +8766,9 @@ Relations</cite></a>. IANA. URL: <a href=
 "https://www.iana.org/assignments/link-relations/">https://www.iana.org/assignments/link-relations/</a></dd>
 <dt id="bib-iec-fotf">[IEC-FOTF]</dt>
 <dd><a href=
-"https://www.iec.ch/basecamp/factory-future/"><cite>Factory of the
+"https://www.iec.ch/basecamp/factory-future"><cite>Factory of the
 future</cite></a>. IEC. October 2015. URL: <a href=
-"https://www.iec.ch/basecamp/factory-future/">https://www.iec.ch/basecamp/factory-future/</a></dd>
+"https://www.iec.ch/basecamp/factory-future">https://www.iec.ch/basecamp/factory-future</a></dd>
 <dt id="bib-iot-schema-org">[IOT-SCHEMA-ORG]</dt>
 <dd><a href="https://www.w3.org/community/iotschema/"><cite>Schema
 Extensions for IoT Community Group</cite></a>. URL: <a href=
@@ -8897,7 +8896,7 @@ Lefrançois. W3C. 19 October 2017. W3C Recommendation. URL: <a href=
 <dd><a href="https://www.w3.org/TR/WCAG22/"><cite>Web Content
 Accessibility Guidelines (WCAG) 2.2</cite></a>. Michael Cooper;
 Andrew Kirkpatrick; Alastair Campbell; Rachael Bradley Montgomery;
-Charles Adams. W3C. 20 July 2023. W3C Proposed Recommendation. URL:
+Charles Adams. W3C. 5 October 2023. W3C Recommendation. URL:
 <a href=
 "https://www.w3.org/TR/WCAG22/">https://www.w3.org/TR/WCAG22/</a></dd>
 <dt id="bib-wot-binding-templates">[WOT-BINDING-TEMPLATES]</dt>

--- a/publication/ver11/5-rec/Overview.html
+++ b/publication/ver11/5-rec/Overview.html
@@ -102,7 +102,7 @@ dd{margin-left:0}
 }
 </style>
 
-<style type="text/css">
+<style>
 
     a[href].internalDFN {
       color: inherit;

--- a/publication/ver11/5-rec/Overview.html
+++ b/publication/ver11/5-rec/Overview.html
@@ -151,7 +151,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2023/software-license",
-  "datePublished": "2023-10-02",
+  "datePublished": "2023-10-03",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -1133,7 +1133,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "shortName": "wot-architecture11",
   "copyrightStart": 2017,
   "wgPublicList": "public-wot-wg",
-  "errata": "https://w3c.github.io/wot-architecture/errata/v11.md",
+  "errata": "https://w3c.github.io/wot-architecture/errata11.html",
   "implementationReportURI": "https://w3c.github.io/wot-architecture/testing/report11.html",
   "github": {
     "repoURL": "https://github.com/w3c/wot-architecture",
@@ -1454,8 +1454,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2023-10-02T00:00:00.000Z",
-  "generatedSubtitle": "W3C Recommendation 02 October 2023"
+  "publishISODate": "2023-10-03T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 03 October 2023"
 }
 </script>
 <link rel="stylesheet" href=
@@ -1471,14 +1471,14 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 1.1</h1>
 <p id="w3c-state"><a href=
 "https://www.w3.org/standards/types#REC">W3C Recommendation</a>
-<time class="dt-published" datetime="2023-10-02">02 October
+<time class="dt-published" datetime="2023-10-03">03 October
 2023</time></p>
 <details open="">
 <summary>More details about this document</summary>
 <dl>
 <dt>This version:</dt>
 <dd><a class="u-url" href=
-"https://www.w3.org/TR/2023/REC-wot-architecture11-20231002/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231002/</a></dd>
+"https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/</a></dd>
 <dt>Latest published version:</dt>
 <dd><a href=
 "https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a></dd>
@@ -1538,7 +1538,7 @@ public-wot-wg@w3.org</a> with subject line
 "https://lists.w3.org/Archives/Public/public-wot-wg">archives</a>)</dd>
 <dt>Errata:</dt>
 <dd><a href=
-"https://w3c.github.io/wot-architecture/errata/v11.md">Errata
+"https://w3c.github.io/wot-architecture/errata11.html">Errata
 exists</a>.</dd>
 <dt>Previous Recommendation</dt>
 <dd><a href=
@@ -8941,8 +8941,8 @@ November 2010. URL: <a href=
 <dt id="bib-wot-scripting-api">[WOT-SCRIPTING-API]</dt>
 <dd><a href="https://www.w3.org/TR/wot-scripting-api/"><cite>Web of
 Things (WoT) Scripting API</cite></a>. Zoltan Kis; Daniel Peintner;
-Cristiano Aguzzi; Johannes Hund; Kazuaki Nimura. W3C. 24 November
-2020. W3C Working Group Note. URL: <a href=
+Cristiano Aguzzi; Johannes Hund; Kazuaki Nimura. W3C. 3 October
+2023. W3C Working Group Note. URL: <a href=
 "https://www.w3.org/TR/wot-scripting-api/">https://www.w3.org/TR/wot-scripting-api/</a></dd>
 <dt id="bib-wot-security">[WOT-SECURITY]</dt>
 <dd><a href="https://www.w3.org/TR/wot-security/"><cite>Web of

--- a/publication/ver11/5-rec/index.html
+++ b/publication/ver11/5-rec/index.html
@@ -97,7 +97,7 @@
           date: "13 June 2019"
         },
         "IEC-FOTF": {
-          href: "https://www.iec.ch/basecamp/factory-future/",
+          href: "https://www.iec.ch/basecamp/factory-future",
           title: "Factory of the future",
           publisher: "IEC",
           date: "October 2015"
@@ -4891,8 +4891,8 @@ Services returning Thing Descriptions with immutable IDs SHOULD use some form of
            regarding the concept of "Web of Things" that started as an academic
            initiative in the form of publications such as [[?WOT-PIONEERS-1]] [[?WOT-PIONEERS-2]]
            [[?WOT-PIONEERS-3]] [[?WOT-PIONEERS-4]] and, starting
-           in 2010, a yearly <a href="https://webofthings.org/events/wot/">
-           International Workshop on the Web of Things</a>.</p>
+           in 2010, an
+           <i>International Workshop on the Web of Things</i>.</p>
            <p>Finally, special thanks to Joerg Heuer for leading the WoT IG for 2 years
             from its inception and guiding the group to come up with the concept of
             WoT building blocks including the Thing Description.</p>

--- a/publication/ver11/5-rec/index.html
+++ b/publication/ver11/5-rec/index.html
@@ -21,7 +21,7 @@
       shortName: "wot-architecture11",
       copyrightStart: 2017,
       wgPublicList: "public-wot-wg",
-      errata: "https://w3c.github.io/wot-architecture/errata/v11.md",
+      errata: "https://w3c.github.io/wot-architecture/errata11.html",
       implementationReportURI: "https://w3c.github.io/wot-architecture/testing/report11.html",
       github: {
         repoURL: "https://github.com/w3c/wot-architecture",

--- a/publication/ver11/5-rec/index.html
+++ b/publication/ver11/5-rec/index.html
@@ -271,7 +271,7 @@
       }
     };
   </script>
-  <style type="text/css">
+  <style>
     a[href].internalDFN {
       color: inherit;
       border-bottom: 1px solid #99c;

--- a/publication/ver11/5-rec/static.html
+++ b/publication/ver11/5-rec/static.html
@@ -152,7 +152,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2023/software-license",
-  "datePublished": "2023-10-02",
+  "datePublished": "2023-10-03",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -1131,7 +1131,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "shortName": "wot-architecture11",
   "copyrightStart": 2017,
   "wgPublicList": "public-wot-wg",
-  "errata": "https://w3c.github.io/wot-architecture/errata/v11.md",
+  "errata": "https://w3c.github.io/wot-architecture/errata11.html",
   "implementationReportURI": "https://w3c.github.io/wot-architecture/testing/report11.html",
   "github": {
     "repoURL": "https://github.com/w3c/wot-architecture",
@@ -1452,8 +1452,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2023-10-02T00:00:00.000Z",
-  "generatedSubtitle": "W3C Recommendation 02 October 2023"
+  "publishISODate": "2023-10-03T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 03 October 2023"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-REC"></head>
 
@@ -1461,12 +1461,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Architecture 1.1</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2023-10-02">02 October 2023</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2023-10-03">03 October 2023</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2023/REC-wot-architecture11-20231002/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231002/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>
@@ -1509,7 +1509,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         <a href="https://github.com/w3c/wot-architecture/issues/new/choose">new issue</a>,
         <a href="https://github.com/w3c/wot-architecture/issues/">open issues</a>)
       </dd><dd><a href="mailto:public-wot-wg@w3.org?subject=%5Bwot-architecture11%5D%20YOUR%20TOPIC%20HERE">public-wot-wg@w3.org</a> with subject line <kbd>[wot-architecture11] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-wot-wg">archives</a>)</dd>
-        <dt>Errata:</dt><dd><a href="https://w3c.github.io/wot-architecture/errata/v11.md">Errata exists</a>.</dd>
+        <dt>Errata:</dt><dd><a href="https://w3c.github.io/wot-architecture/errata11.html">Errata exists</a>.</dd>
         <dt>Previous Recommendation</dt><dd>
     <a href="https://www.w3.org/TR/2020/REC-wot-architecture-20200409/">https://www.w3.org/TR/2020/REC-wot-architecture-20200409/</a>
   </dd><dt>Contributors</dt><dd>
@@ -6217,7 +6217,7 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">SHO
     </dd><dt id="bib-wot-pioneers-4">[WOT-PIONEERS-4]</dt><dd>
       <a href="https://ieeexplore.ieee.org/abstract/document/5678452"><cite>A Resource Oriented Architecture for the Web of Things</cite></a>. Dominique Guinard; Vlad Trifa; Erik Wilde.  Proceedings of Internet of Things 2010 International Conference (IoT 2010). Tokyo, Japan. November 2010. URL: <a href="https://ieeexplore.ieee.org/abstract/document/5678452">https://ieeexplore.ieee.org/abstract/document/5678452</a>
     </dd><dt id="bib-wot-scripting-api">[WOT-SCRIPTING-API]</dt><dd>
-      <a href="https://www.w3.org/TR/wot-scripting-api/"><cite>Web of Things (WoT) Scripting API</cite></a>. Zoltan Kis; Daniel Peintner; Cristiano Aguzzi; Johannes Hund; Kazuaki Nimura.  W3C. 24 November 2020. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wot-scripting-api/">https://www.w3.org/TR/wot-scripting-api/</a>
+      <a href="https://www.w3.org/TR/wot-scripting-api/"><cite>Web of Things (WoT) Scripting API</cite></a>. Zoltan Kis; Daniel Peintner; Cristiano Aguzzi; Johannes Hund; Kazuaki Nimura.  W3C. 3 October 2023. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wot-scripting-api/">https://www.w3.org/TR/wot-scripting-api/</a>
     </dd><dt id="bib-wot-security">[WOT-SECURITY]</dt><dd>
       <a href="https://www.w3.org/TR/wot-security/"><cite>Web of Things (WoT) Security and Privacy Guidelines</cite></a>. ; Michael McCool; Elena Reshetova.  W3C. March 2019. URL: <a href="https://www.w3.org/TR/wot-security/">https://www.w3.org/TR/wot-security/</a>
     </dd><dt id="bib-y.4409-y.2070">[Y.4409-Y.2070]</dt><dd>

--- a/publication/ver11/5-rec/static.html
+++ b/publication/ver11/5-rec/static.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
-<meta name="generator" content="ReSpec 34.1.8">
+<meta name="generator" content="ReSpec 34.2.0">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
 .issue-label{text-transform:initial}
@@ -152,7 +152,7 @@ dd{margin-left:0}
   "name": "Web of Things (WoT) Architecture 1.1",
   "inLanguage": "en-US",
   "license": "https://www.w3.org/Consortium/Legal/2023/software-license",
-  "datePublished": "2023-10-03",
+  "datePublished": "2023-10-24",
   "copyrightHolder": {
     "name": "World Wide Web Consortium",
     "url": "https://www.w3.org/"
@@ -668,10 +668,10 @@ dd{margin-left:0}
       }
     },
     {
-      "id": "https://www.iec.ch/basecamp/factory-future/",
+      "id": "https://www.iec.ch/basecamp/factory-future",
       "type": "TechArticle",
       "name": "Factory of the future",
-      "url": "https://www.iec.ch/basecamp/factory-future/",
+      "url": "https://www.iec.ch/basecamp/factory-future",
       "publisher": {
         "name": "IEC"
       }
@@ -1230,7 +1230,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "date": "13 June 2019"
     },
     "IEC-FOTF": {
-      "href": "https://www.iec.ch/basecamp/factory-future/",
+      "href": "https://www.iec.ch/basecamp/factory-future",
       "title": "Factory of the future",
       "publisher": "IEC",
       "date": "October 2015",
@@ -1452,8 +1452,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "wot-security"
     }
   },
-  "publishISODate": "2023-10-03T00:00:00.000Z",
-  "generatedSubtitle": "W3C Recommendation 03 October 2023"
+  "publishISODate": "2023-10-24T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 24 October 2023"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-REC"></head>
 
@@ -1461,12 +1461,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Architecture 1.1</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2023-10-03">03 October 2023</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2023-10-24">24 October 2023</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231003/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2023/REC-wot-architecture11-20231024/">https://www.w3.org/TR/2023/REC-wot-architecture11-20231024/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>
@@ -6097,8 +6097,8 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">SHO
            regarding the concept of "Web of Things" that started as an academic
            initiative in the form of publications such as [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-pioneers-1" title="Mobile Service Interaction with the Web of Things">WOT-PIONEERS-1</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-pioneers-2" title="Putting Things to REST">WOT-PIONEERS-2</a></cite>]
            [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-pioneers-3" title="Poster Abstract: Dyser – Towards a Real-Time Search Engine for the Web of Things">WOT-PIONEERS-3</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-pioneers-4" title="A Resource Oriented Architecture for the Web of Things">WOT-PIONEERS-4</a></cite>] and, starting
-           in 2010, a yearly <a href="https://webofthings.org/events/wot/">
-           International Workshop on the Web of Things</a>.</p>
+           in 2010, an
+           <i>International Workshop on the Web of Things</i>.</p>
            <p>Finally, special thanks to Joerg Heuer for leading the WoT IG for 2 years
             from its inception and guiding the group to come up with the concept of
             WoT building blocks including the Thing Description.</p>
@@ -6161,7 +6161,7 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">SHO
     </dd><dt id="bib-iana-relations">[IANA-RELATIONS]</dt><dd>
       <a href="https://www.iana.org/assignments/link-relations/"><cite>Link Relations</cite></a>.  IANA. URL: <a href="https://www.iana.org/assignments/link-relations/">https://www.iana.org/assignments/link-relations/</a>
     </dd><dt id="bib-iec-fotf">[IEC-FOTF]</dt><dd>
-      <a href="https://www.iec.ch/basecamp/factory-future/"><cite>Factory of the future</cite></a>.  IEC. October 2015. URL: <a href="https://www.iec.ch/basecamp/factory-future/">https://www.iec.ch/basecamp/factory-future/</a>
+      <a href="https://www.iec.ch/basecamp/factory-future"><cite>Factory of the future</cite></a>.  IEC. October 2015. URL: <a href="https://www.iec.ch/basecamp/factory-future">https://www.iec.ch/basecamp/factory-future</a>
     </dd><dt id="bib-iot-schema-org">[IOT-SCHEMA-ORG]</dt><dd>
       <a href="https://www.w3.org/community/iotschema/"><cite>Schema Extensions for IoT Community Group</cite></a>. URL: <a href="https://www.w3.org/community/iotschema/">https://www.w3.org/community/iotschema/</a>
     </dd><dt id="bib-iso-iec-2382">[ISO-IEC-2382]</dt><dd>
@@ -6205,7 +6205,7 @@ Services returning Thing Descriptions with immutable IDs <em class="rfc2119">SHO
     </dd><dt id="bib-vocab-ssn">[VOCAB-SSN]</dt><dd>
       <a href="https://www.w3.org/TR/vocab-ssn/"><cite>Semantic Sensor Network Ontology</cite></a>. Armin Haller; Krzysztof Janowicz; Simon Cox; Danh Le Phuoc; Kerry Taylor; Maxime Lefrançois.  W3C. 19 October 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/vocab-ssn/">https://www.w3.org/TR/vocab-ssn/</a>
     </dd><dt id="bib-wcag22">[WCAG22]</dt><dd>
-      <a href="https://www.w3.org/TR/WCAG22/"><cite>Web Content Accessibility Guidelines (WCAG) 2.2</cite></a>. Michael Cooper; Andrew Kirkpatrick; Alastair Campbell; Rachael Bradley Montgomery; Charles Adams.  W3C. 20 July 2023. W3C Proposed Recommendation. URL: <a href="https://www.w3.org/TR/WCAG22/">https://www.w3.org/TR/WCAG22/</a>
+      <a href="https://www.w3.org/TR/WCAG22/"><cite>Web Content Accessibility Guidelines (WCAG) 2.2</cite></a>. Michael Cooper; Andrew Kirkpatrick; Alastair Campbell; Rachael Bradley Montgomery; Charles Adams.  W3C. 5 October 2023. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WCAG22/">https://www.w3.org/TR/WCAG22/</a>
     </dd><dt id="bib-wot-binding-templates">[WOT-BINDING-TEMPLATES]</dt><dd>
       <a href="https://www.w3.org/TR/wot-binding-templates/"><cite>Web of Things (WoT) Binding Templates</cite></a>. Michael Koster; Ege Korkan.  W3C. 28 September 2023. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wot-binding-templates/">https://www.w3.org/TR/wot-binding-templates/</a>
     </dd><dt id="bib-wot-pioneers-1">[WOT-PIONEERS-1]</dt><dd>

--- a/publication/ver11/5-rec/static.html
+++ b/publication/ver11/5-rec/static.html
@@ -99,7 +99,7 @@ dd{margin-left:0}
 </style>
   
   
-<style type="text/css">
+<style>
 
     a[href].internalDFN {
       color: inherit;


### PR DESCRIPTION
- Update to use HTML errata template
- HTML tidy run, all errors fixed
- [HTML Checker](https://validator.w3.org/nu/?doc=https%3A%2F%2Fw3c.github.io%2Fwot-architecture%2Fpublication%2Fver11%2F5-rec%2FOverview.html)
    - The type attribute for the style element is not needed and should be omitted. (fixed)
- [CSS Checker](https://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Fw3c.github.io%2Fwot-discovery%2Fpublication%2F6-rec%2FOverview.html&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en)
    - minor warning for included style sheet (ignored): https://www.w3.org/StyleSheets/TR/2021/base.css
- [Link checker](https://validator.w3.org/checklink?uri=https%3A%2F%2Fw3c.github.io%2Fwot-architecture%2Fpublication%2Fver11%2F5-rec%2FOverview.html&hide_type=all&depth=&check=Check): some ignorable errors
    - 404 not found (well, obviously...)
        - https://www.w3.org/TR/2023/REC-wot-architecture11-20231002/
    - Complains about broken fragments for the following, but they resolve correctly:
        - https://www.iso.org/obp/ui/#iso:std:iso-iec:2382:ed-1:v2:en
        - https://www.iso.org/obp/ui/#iso:std:iso-iec:27000:ed-5:v1:en
        - https://www.iso.org/obp/ui/#iso:std:iso-iec:29100:ed-1:v1:en
      - Complains about temporary redirect, but this inserted by W3C tools: https://www.w3.org/Consortium/Legal/ipr-notice
      - Complains about redirect from https://www.intel.com/ to https://www.intel.com/content/www/us/en/homepage.html, but first URL used intentionally; similar for panasonic, fujitsu, huawei, etc.
      - Redirection for ETSI to upgrade from http to https (not changed, in SpecRef)
      - Redirection for paper reference, Mobile Service Interaction (not changed, in SpecRef)
      - Redirection to drop www from ethz URL (not changed, in SpecRef)
      - Added trailing slash to https://lists.w3.org/Archives/Public/public-wot-wg/ (not changed, autogenerated)
      - REMOVE trailing slash from https://www.iec.ch/basecamp/factory-future/ (changed, local ref)
      - Broken URL (500, hostname verification failed): https://webofthings.org/events/wot/ (link removed)
- [Pubrules](https://www.w3.org/pubrules/?url=https%3A%2F%2Fw3c.github.io%2Fwot-architecture%2Fpublication%2Fver11%2F5-rec%2FOverview.html&profile=REC&validation=simple-validation&informativeOnly=false&echidnaReady=false&patentPolicy=pp2020)
     - Currently getting errors around copyright notice, patent policy etc. but that should be automatically inserted based on charter
     - Also getting errors about "group not found", etc. but it seems the API service supporting that is down, e.g. https://respec.org/w3c/groups/ - getting an 503 error in Respec too.  "group" is in fact set to "wg/wot" just like TD.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-architecture/pull/935.html" title="Last updated on Oct 24, 2023, 5:58 PM UTC (cef7251)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-architecture/935/a92401d...mmccool:cef7251.html" title="Last updated on Oct 24, 2023, 5:58 PM UTC (cef7251)">Diff</a>